### PR TITLE
basic observer ui

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/hud/ObserverDisplayEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/hud/ObserverDisplayEvents.java
@@ -1,0 +1,62 @@
+package com.solegendary.reignofnether.hud;
+
+import com.solegendary.reignofnether.guiscreen.TopdownGui;
+import com.solegendary.reignofnether.hud.Button;
+import com.solegendary.reignofnether.orthoview.OrthoviewClientEvents;
+import com.solegendary.reignofnether.player.PlayerClientEvents;
+import com.solegendary.reignofnether.resources.Resources;
+import com.solegendary.reignofnether.resources.ResourcesClientEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.ScreenEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+public class ObserverDisplayEvents {
+
+    private static final Minecraft MC = Minecraft.getInstance();
+
+    private static ArrayList<ObserverPlayerDisplay> playerDisplays = new ArrayList<>();
+
+    @SubscribeEvent
+    public static void onDrawScreen(ScreenEvent.Render.Post evt) {
+
+        if (!OrthoviewClientEvents.isEnabled() || !(evt.getScreen() instanceof TopdownGui)) {
+            return;
+        }
+
+        if (MC.level == null) {
+            return;
+        }
+
+        if (PlayerClientEvents.isRTSPlayer) {
+            return; // only render for spectators
+        }
+
+        var mouseX = evt.getMouseX();
+        var mouseY = evt.getMouseY();
+
+        int screenWidth = MC.getWindow().getGuiScaledWidth();
+        int screenHeight = MC.getWindow().getGuiScaledHeight();
+
+        int blitX = screenWidth / 2 - ObserverPlayerDisplay.DISPLAY_WIDTH / 2;
+        int blitY = 0;
+
+        var guiGraphics = evt.getGuiGraphics();
+
+        playerDisplays.removeIf(r -> !ResourcesClientEvents.resourcesList.contains(r.resources));
+
+        var trackedResources = playerDisplays.stream().map(d -> d.resources).collect(Collectors.toCollection(ArrayList::new));
+        for (Resources resources : ResourcesClientEvents.resourcesList) {
+            if (!trackedResources.contains(resources)) {
+                playerDisplays.add(new ObserverPlayerDisplay(resources));
+            }
+        }
+
+        for (ObserverPlayerDisplay playerDisplay : playerDisplays) {
+            playerDisplay.render(guiGraphics, blitX, blitY);
+            blitY += Button.DEFAULT_ICON_FRAME_SIZE;
+        }
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/hud/ObserverPlayerDisplay.java
+++ b/src/main/java/com/solegendary/reignofnether/hud/ObserverPlayerDisplay.java
@@ -50,6 +50,15 @@ public class ObserverPlayerDisplay {
     public static final int DISPLAY_WIDTH = PLAYER_FRAME_WIDTH + RESOURCE_FRAME_WIDTH * 4 + SUPPLY_DETAIL_FRAME_WIDTH; // total width of a player display
 
     private void renderPlayer(GuiGraphics guiGraphics, int x, int y) {
+
+        MyRenderer.renderFrameWithBg(guiGraphics,
+                x,
+                y,
+                PLAYER_FRAME_WIDTH,
+                Button.DEFAULT_ICON_FRAME_SIZE,
+                frameBgColour
+        );
+        
         if (this.player != null && this.player.isSkinLoaded()) {
             var iconLocation = player.getSkinTextureLocation();
             //RenderSystem.setShaderTexture(0, iconLocation);
@@ -77,14 +86,7 @@ public class ObserverPlayerDisplay {
                     Button.DEFAULT_ICON_SIZE
             );
         }
-
-        MyRenderer.renderFrameWithBg(guiGraphics,
-                x,
-                y,
-                PLAYER_FRAME_WIDTH,
-                Button.DEFAULT_ICON_FRAME_SIZE,
-                frameBgColour
-        );
+        
         guiGraphics.drawString(
                 MC.font,
                 this.resources.ownerName,

--- a/src/main/java/com/solegendary/reignofnether/hud/ObserverPlayerDisplay.java
+++ b/src/main/java/com/solegendary/reignofnether/hud/ObserverPlayerDisplay.java
@@ -1,0 +1,221 @@
+package com.solegendary.reignofnether.hud;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.solegendary.reignofnether.ReignOfNether;
+import com.solegendary.reignofnether.building.BuildingClientEvents;
+import com.solegendary.reignofnether.hud.Button;
+import com.solegendary.reignofnether.resources.ResourceName;
+import com.solegendary.reignofnether.resources.Resources;
+import com.solegendary.reignofnether.unit.UnitClientEvents;
+import com.solegendary.reignofnether.unit.interfaces.Unit;
+import com.solegendary.reignofnether.unit.interfaces.WorkerUnit;
+import com.solegendary.reignofnether.util.MyRenderer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+
+public class ObserverPlayerDisplay {
+
+    private static final Minecraft MC = Minecraft.getInstance();
+
+    public final Resources resources;
+    public final AbstractClientPlayer player;
+    public final ResourceLocation defaultIconLocation = new ResourceLocation(ReignOfNether.MOD_ID, "textures/icons/blocks/command_block_back.png");
+
+    public ObserverPlayerDisplay(Resources resources) {
+        this.resources = resources;
+        var server = MC.getCurrentServer();
+        if (server != null) {
+            this.player = MC.level.players().stream().filter(p -> p.getName().getString().equals(this.resources.ownerName)).findFirst().orElse(null);
+        } else if (MC.player.getName().getString().equals(this.resources.ownerName)) {
+            this.player = MC.player;
+            var loaded = this.player.isSkinLoaded();
+        } else {
+            this.player = null;
+        }
+    }
+
+    private final static int iconBgColour = 0x64000000;
+    private final static int frameBgColour = 0xA0000000;
+
+
+    private static final int PLAYER_FRAME_WIDTH = Button.DEFAULT_ICON_FRAME_SIZE * 5; // frame containing player name + player icon + race icon
+    private static final int PLAYER_VALUE_WIDTH = Button.DEFAULT_ICON_FRAME_SIZE * 4; // name of the player
+    private static final int RESOURCE_FRAME_WIDTH = Button.DEFAULT_ICON_FRAME_SIZE * 3; // frame containing a resource value + icon
+    private static final int RESOURCE_VALUE_WIDTH = Button.DEFAULT_ICON_FRAME_SIZE * 2; // value of the resource
+    private static final int SUPPLY_DETAIL_FRAME_WIDTH = Button.DEFAULT_ICON_FRAME_SIZE * 4; // frame containing a resource value + icon
+    public static final int DISPLAY_WIDTH = PLAYER_FRAME_WIDTH + RESOURCE_FRAME_WIDTH * 4 + SUPPLY_DETAIL_FRAME_WIDTH; // total width of a player display
+
+    private void renderPlayer(GuiGraphics guiGraphics, int x, int y) {
+        if (this.player != null && this.player.isSkinLoaded()) {
+            var iconLocation = player.getSkinTextureLocation();
+            //RenderSystem.setShaderTexture(0, iconLocation);
+            // draw base layer
+            guiGraphics.blit(iconLocation,
+                    x + 4, y + 4,
+                    Button.DEFAULT_ICON_SIZE, Button.DEFAULT_ICON_SIZE,
+                    8.0f, 8.0f, // where on texture to start drawing from
+                    8, 8, // dimensions of blit texture
+                    64, 64 // size of texture itself (if < dimensions, texture is repeated)
+            );
+            // draw hat
+            guiGraphics.blit(iconLocation,
+                    x + 4, y + 4,
+                    Button.DEFAULT_ICON_SIZE, Button.DEFAULT_ICON_SIZE,
+                    40.0f, 8.0f, // where on texture to start drawing from
+                    8, 8, // dimensions of blit texture
+                    64, 64 // size of texture itself (if < dimensions, texture is repeated)
+            );
+        } else {
+            MyRenderer.renderIcon(guiGraphics,
+                    defaultIconLocation,
+                    x + 4,
+                    y + 4,
+                    Button.DEFAULT_ICON_SIZE
+            );
+        }
+
+        MyRenderer.renderFrameWithBg(guiGraphics,
+                x,
+                y,
+                PLAYER_FRAME_WIDTH,
+                Button.DEFAULT_ICON_FRAME_SIZE,
+                frameBgColour
+        );
+        guiGraphics.drawString(
+                MC.font,
+                this.resources.ownerName,
+                x + (Button.DEFAULT_ICON_FRAME_SIZE),
+                y + (Button.DEFAULT_ICON_SIZE / 2) + 1,
+                0xFFFFFF
+        );
+    }
+
+    private void renderResource(GuiGraphics guiGraphics, int x, int y, ResourceName resource) {
+        String iconPath;
+        String value;
+        int color = 0xFFFFFF;
+        switch (resource) {
+            case FOOD -> {
+                iconPath = "textures/icons/items/wheat.png";
+                value = String.valueOf(resources.food);
+                color = 0xE8BC5F;
+            }
+            case WOOD -> {
+                iconPath = "textures/icons/items/wood.png";
+                value = String.valueOf(resources.wood);
+                color = 0xA3753B;
+            }
+            case ORE -> {
+                iconPath = "textures/icons/items/iron_ore.png";
+                value = String.valueOf(resources.ore);
+                color = 0xFFF4ED;
+            }
+            default -> {
+                iconPath = "textures/icons/items/bed.png";
+                var used = UnitClientEvents.getCurrentPopulation(this.resources.ownerName);
+                var produced = BuildingClientEvents.getTotalPopulationSupply(this.resources.ownerName);
+                value = used + "/" + produced;
+                color = used > produced
+                        ? 0xFF0000
+                        : 0xFFFFFF;
+            }
+        }
+
+        MyRenderer.renderFrameWithBg(guiGraphics,
+                x,
+                y,
+                RESOURCE_FRAME_WIDTH,
+                Button.DEFAULT_ICON_FRAME_SIZE,
+                frameBgColour
+        );
+
+        MyRenderer.renderIcon(guiGraphics,
+                new ResourceLocation(ReignOfNether.MOD_ID, iconPath),
+                x + 4,
+                y + 4,
+                Button.DEFAULT_ICON_SIZE
+        );
+
+        guiGraphics.drawString(
+                MC.font,
+                value,
+                x + (Button.DEFAULT_ICON_FRAME_SIZE),
+                y + (Button.DEFAULT_ICON_SIZE / 2) + 1,
+                color
+        );
+    }
+
+    private void renderSupplyDetail(GuiGraphics guiGraphics, int x, int y) {
+        int civilianSupply = 0;
+        int militarySupply = 0;
+
+        for (LivingEntity entities : UnitClientEvents.getAllUnits()) {
+            if (!(entities instanceof Unit unit)) {
+                continue;
+            }
+
+            if (!this.resources.ownerName.equals(unit.getOwnerName())) {
+                continue;
+            }
+
+            if (unit instanceof WorkerUnit) {
+                civilianSupply += unit.getCost().population;
+            } else {
+                militarySupply += unit.getCost().population;
+            }
+        }
+
+        MyRenderer.renderFrameWithBg(guiGraphics,
+                x,
+                y,
+                SUPPLY_DETAIL_FRAME_WIDTH,
+                Button.DEFAULT_ICON_FRAME_SIZE,
+                frameBgColour
+        );
+
+        MyRenderer.renderIcon(guiGraphics,
+                //new ResourceLocation(ReignOfNether.MOD_ID, "textures/cursors/customcursor_shovel.png"),
+                //new ResourceLocation(ReignOfNether.MOD_ID, "textures/icons/items/pickaxe.png"),
+                new ResourceLocation(ReignOfNether.MOD_ID, "textures/icons/items/shovel.png"),
+                x + 4,
+                y + 4,
+                Button.DEFAULT_ICON_SIZE
+        );
+
+        guiGraphics.drawString(
+                MC.font,
+                "" + civilianSupply,
+                x + (Button.DEFAULT_ICON_FRAME_SIZE),
+                y + (Button.DEFAULT_ICON_SIZE / 2) + 1,
+                0xFFFFFF
+        );
+
+        MyRenderer.renderIcon(guiGraphics,
+                new ResourceLocation(ReignOfNether.MOD_ID, "textures/icons/items/sword_and_bow.png"),
+                x + SUPPLY_DETAIL_FRAME_WIDTH / 2 + 4,
+                y + 4,
+                Button.DEFAULT_ICON_SIZE
+        );
+
+        guiGraphics.drawString(
+                MC.font,
+                "" + militarySupply,
+                x + SUPPLY_DETAIL_FRAME_WIDTH / 2 + (Button.DEFAULT_ICON_FRAME_SIZE),
+                y + (Button.DEFAULT_ICON_SIZE / 2) + 1,
+                0xFFFFFF
+        );
+    }
+
+    public void render(GuiGraphics guiGraphics, int x, int y) {
+        this.renderPlayer(guiGraphics, x, y); // icon, name
+        this.renderResource(guiGraphics, x += PLAYER_FRAME_WIDTH, y, ResourceName.FOOD);
+        this.renderResource(guiGraphics, x += RESOURCE_FRAME_WIDTH, y, ResourceName.WOOD);
+        this.renderResource(guiGraphics, x += RESOURCE_FRAME_WIDTH, y, ResourceName.ORE);
+        this.renderResource(guiGraphics, x += RESOURCE_FRAME_WIDTH, y, ResourceName.NONE); // supply
+        this.renderSupplyDetail(guiGraphics, x += RESOURCE_FRAME_WIDTH, y);
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/registrars/ClientEventRegistrar.java
+++ b/src/main/java/com/solegendary/reignofnether/registrars/ClientEventRegistrar.java
@@ -20,6 +20,7 @@ import com.solegendary.reignofnether.healthbars.HealthBarClientEvents;
 import com.solegendary.reignofnether.hero.HeroClientEvents;
 import com.solegendary.reignofnether.hero.HeroServerEvents;
 import com.solegendary.reignofnether.hud.HudClientEvents;
+import com.solegendary.reignofnether.hud.ObserverDisplayEvents;
 import com.solegendary.reignofnether.hud.TitleClientEvents;
 import com.solegendary.reignofnether.minimap.MinimapClientEvents;
 import com.solegendary.reignofnether.orthoview.OrthoviewClientEvents;
@@ -84,6 +85,7 @@ public class ClientEventRegistrar {
         vanillaEventBus.register(HeroClientEvents.class);
         vanillaEventBus.register(CustomBuildingClientEvents.class);
         vanillaEventBus.register(SoundClientEvents.class);
+        vanillaEventBus.register(ObserverDisplayEvents.class);
 
         // to allow singleplayer integrated server to work
         vanillaEventBus.register(GameruleServerEvents.class);


### PR DESCRIPTION
Add an observer overlay:
- Only visible for spectators (non-RTS players in RTS mode)
- Display portrait, name, resources, supply and supply distribution for each players

The overlay is managed by a dedicated `ObserverDisplayEvents` class, so the `HudClientEvents.onDrawScreen` method doesn't get even bigger. The `ObserverPlayerDisplay` class displays the data per player. The `ResourcesClientEvents.resourcesList` is used as the source of RTS players list.

<img width="939" height="138" alt="image" src="https://github.com/user-attachments/assets/b9e6d32b-7091-45c1-a3ad-13529874bbb0" />
