### PR TITLE
1.20.1 1.3.3. Formation Drag-Move + Mobile devices crash fix

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/cursor/CursorClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/cursor/CursorClientEvents.java
@@ -75,6 +75,10 @@ public class CursorClientEvents {
     // pos of cursor on screen for box selections
     private static Vec2 cursorLeftClickDownPos = new Vec2(-1, -1);
     private static Vec2 cursorLeftClickDragPos = new Vec2(-1, -1);
+    private static Vec2 cursorRightClickDownPos = new Vec2(-1, -1);
+    private static Vec2 cursorRightClickDragPos = new Vec2(-1, -1);
+    private static BlockPos rightClickStartBp = new BlockPos(0, 0, 0);
+    private static final int DRAG_THRESHOLD = 5;
     // action that is performed on the next left click
     private static UnitAction leftClickAction = null;
     private static SandboxAction leftClickSandboxAction = null;
@@ -93,6 +97,26 @@ public class CursorClientEvents {
 
     public static SandboxAction getLeftClickSandboxAction() {
         return leftClickSandboxAction;
+    }
+
+    public static boolean isRightDragCouldStart() {
+        return rightClickDown;
+    }
+
+    public static boolean isRightDragActive() {
+        return rightClickDown && cursorRightClickDownPos.distanceToSqr(cursorRightClickDragPos) > (DRAG_THRESHOLD * DRAG_THRESHOLD);
+    }
+
+    public static Vec2 getCursorRightClickDownPos() {
+        return cursorRightClickDownPos;
+    }
+
+    public static Vec2 getCursorRightClickDragPos() {
+        return cursorRightClickDragPos;
+    }
+
+    public static BlockPos getRightClickStartBp() {
+        return rightClickStartBp;
     }
 
     public static void setLeftClickAction(UnitAction actionName) {
@@ -327,17 +351,23 @@ public class CursorClientEvents {
             leftClickDown = true;
         }
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+            cursorRightClickDownPos = new Vec2(floor(evt.getMouseX()), floor(evt.getMouseY()));
+            cursorRightClickDragPos = new Vec2(floor(evt.getMouseX()), floor(evt.getMouseY()));
+            rightClickStartBp = getPreselectedBlockPos();
             rightClickDown = true;
         }
     }
 
     @SubscribeEvent
     public static void onMouseDrag(ScreenEvent.MouseDragged.Pre evt) {
-        if (!OrthoviewClientEvents.isEnabled() ||
-                (cursorLeftClickDownPos.x < 0 && cursorLeftClickDownPos.y < 0))
+        if (!OrthoviewClientEvents.isEnabled())
             return;
 
-        cursorLeftClickDragPos = new Vec2(floor(evt.getMouseX()), floor(evt.getMouseY()));
+        if (cursorLeftClickDownPos.x >= 0 || cursorLeftClickDownPos.y >= 0)
+            cursorLeftClickDragPos = new Vec2(floor(evt.getMouseX()), floor(evt.getMouseY()));
+
+        if (rightClickDown)
+            cursorRightClickDragPos = new Vec2(floor(evt.getMouseX()), floor(evt.getMouseY()));
     }
 
     @SubscribeEvent
@@ -392,6 +422,8 @@ public class CursorClientEvents {
         }
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
             rightClickDown = false;
+            cursorRightClickDownPos = new Vec2(-1, -1);
+            cursorRightClickDragPos = new Vec2(-1, -1);
         }
     }
 

--- a/src/main/java/com/solegendary/reignofnether/cursor/CursorClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/cursor/CursorClientEvents.java
@@ -78,7 +78,7 @@ public class CursorClientEvents {
     private static Vec2 cursorRightClickDownPos = new Vec2(-1, -1);
     private static Vec2 cursorRightClickDragPos = new Vec2(-1, -1);
     private static BlockPos rightClickStartBp = new BlockPos(0, 0, 0);
-    private static final int DRAG_THRESHOLD = 5;
+    private static final int DRAG_THRESHOLD = 10;
     // action that is performed on the next left click
     private static UnitAction leftClickAction = null;
     private static SandboxAction leftClickSandboxAction = null;

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -28,7 +28,9 @@ import com.solegendary.reignofnether.blocks.NightCircleMode;
 import com.solegendary.reignofnether.tutorial.TutorialClientEvents;
 import com.solegendary.reignofnether.tutorial.TutorialStage;
 import com.solegendary.reignofnether.unit.UnitAction;
+import com.solegendary.reignofnether.unit.UnitActionItem;
 import com.solegendary.reignofnether.unit.UnitClientEvents;
+import com.solegendary.reignofnether.unit.packets.UnitActionServerboundPacket;
 import com.solegendary.reignofnether.unit.interfaces.Unit;
 import com.solegendary.reignofnether.faction.Faction;
 import com.solegendary.reignofnether.util.ArrayUtil;
@@ -1063,16 +1065,45 @@ public class MinimapClientEvents {
             }
             }
         }
-        else if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+    }
+
+    @SubscribeEvent
+    public static void onMouseRelease(ScreenEvent.MouseButtonReleased.Post evt) {
+        if (!OrthoviewClientEvents.isEnabled() ||
+            OrthoviewClientEvents.isCameraLocked() ||
+            !(MC.screen instanceof TopdownGui)) {
+            return;
+        }
+
+        if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
             if (FormationDragMove.isDragging()) {
-                FormationDragMove.endDrag(UnitClientEvents.getSelectedUnits());
+                var pairs = FormationDragMove.endDrag(UnitClientEvents.getSelectedUnits());
+                for (var pair : pairs) {
+                    LivingEntity le = pair.getFirst();
+                    BlockPos targetBp = pair.getSecond();
+                    if (le instanceof Unit unit) {
+                        int[] singleUnitId = new int[]{le.getId()};
+                        new UnitActionItem(
+                            MC.player.getName().getString(),
+                            UnitAction.MOVE, -1, singleUnitId,
+                            targetBp,
+                            new BlockPos(0, 0, 0)
+                        ).action(MC.level);
+                        PacketHandler.INSTANCE.sendToServer(new UnitActionServerboundPacket(
+                            MC.player.getName().getString(),
+                            UnitAction.MOVE, -1, singleUnitId,
+                            targetBp,
+                            new BlockPos(0, 0, 0),
+                            Keybindings.shiftMod.isDown()
+                        ));
+                    }
+                }
                 minimapDragStartBp = null;
             } else {
                 BlockPos moveTo = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
                 if (moveTo == null) return;
-                if (altDown) {
+                if (Keybindings.altMod.isDown()) {
                     addMapMarkerForSelfAndAllies((int) evt.getMouseX(), (int) evt.getMouseY());
-                    evt.setCanceled(true);
                     return;
                 }
                 if (!UnitClientEvents.getSelectedUnits().isEmpty()) {

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -106,7 +106,7 @@ public class MinimapClientEvents {
     // rate-limit teleporting from dragging the minimap to prevent being kicked from packet spamming
     private static long lastDragTeleportTimestamp = System.currentTimeMillis();
     private static BlockPos minimapDragStartBp = null;
-	private static boolean minimapRightClickDown = false;
+	public static boolean minimapRightClickDown = false;
 
     private static DynamicTexture mapTexture = new DynamicTexture(worldRadius * 2, worldRadius * 2, true);
     private static RenderType mapRenderType = RenderType.textSeeThrough(Minecraft.getInstance().textureManager.register(

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -1017,7 +1017,7 @@ public class MinimapClientEvents {
             }
         }
         else if (evt.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-			if (!minimapRightClickDown) return;
+			if (!minimapRightClickDown || Keybindings.altMod.isDown() || UnitClientEvents.getSelectedUnits().isEmpty()) return;
             BlockPos currentPos = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
             if (currentPos == null) return;
 
@@ -1068,7 +1068,7 @@ public class MinimapClientEvents {
             }
         }
 		if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-			minimapRightClickDown = isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()) && !UnitClientEvents.getSelectedUnits().isEmpty();
+			minimapRightClickDown = isPointInsideMinimap(evt.getMouseX(), evt.getMouseY());
 		}
     }
 
@@ -1081,10 +1081,6 @@ public class MinimapClientEvents {
         }
 
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-		if (!minimapRightClickDown) {
-			minimapRightClickDown = false;
-			return;
-		}
             if (FormationDragMove.isDragging()) {
                 var pairs = FormationDragMove.endDrag(UnitClientEvents.getSelectedUnits());
                 for (var pair : pairs) {

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -997,7 +997,6 @@ public class MinimapClientEvents {
             return;
         }
 
-        // when clicking on map move player there
         if (evt.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_1 &&
             !Keybindings.shiftMod.isDown() && !OrthoviewClientEvents.isCameraLocked() &&
             lastDragTeleportTimestamp < System.currentTimeMillis() - 100) {
@@ -1010,6 +1009,16 @@ public class MinimapClientEvents {
                     MC.player.getY(),
                     (double) moveTo.getZ()
                 );
+            }
+        }
+        else if (evt.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_2 &&
+            lastDragTeleportTimestamp < System.currentTimeMillis() - 100) {
+            lastDragTeleportTimestamp = System.currentTimeMillis();
+            BlockPos moveTo = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
+            if (moveTo != null && !UnitClientEvents.getSelectedUnits().isEmpty()) {
+                var ids = UnitClientEvents.getSelectedUnits();
+                var idArray = ArrayUtil.livingEntityListToIdArray(ids);
+                UnitClientEvents.sendUnitCommandManual(UnitAction.MOVE, -1, idArray, moveTo);
             }
         }
     }

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -13,6 +13,7 @@ import com.solegendary.reignofnether.building.addon.RangeIndicatorAddon;
 import com.solegendary.reignofnether.building.buildings.shared.AbstractBridge;
 import com.solegendary.reignofnether.cursor.CursorClientEvents;
 import com.solegendary.reignofnether.fogofwar.FogOfWarClientEvents;
+import com.solegendary.reignofnether.unit.FormationDragMove;
 import com.solegendary.reignofnether.guiscreen.TopdownGui;
 import com.solegendary.reignofnether.hud.Button;
 import com.solegendary.reignofnether.keybinds.Keybindings;
@@ -102,6 +103,7 @@ public class MinimapClientEvents {
 
     // rate-limit teleporting from dragging the minimap to prevent being kicked from packet spamming
     private static long lastDragTeleportTimestamp = System.currentTimeMillis();
+    private static BlockPos minimapDragStartBp = null;
 
     private static DynamicTexture mapTexture = new DynamicTexture(worldRadius * 2, worldRadius * 2, true);
     private static RenderType mapRenderType = RenderType.textSeeThrough(Minecraft.getInstance().textureManager.register(
@@ -1011,14 +1013,17 @@ public class MinimapClientEvents {
                 );
             }
         }
-        else if (evt.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_2 &&
-            lastDragTeleportTimestamp < System.currentTimeMillis() - 100) {
-            lastDragTeleportTimestamp = System.currentTimeMillis();
-            BlockPos moveTo = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
-            if (moveTo != null && !UnitClientEvents.getSelectedUnits().isEmpty()) {
-                var ids = UnitClientEvents.getSelectedUnits();
-                var idArray = ArrayUtil.livingEntityListToIdArray(ids);
-                UnitClientEvents.sendUnitCommandManual(UnitAction.MOVE, -1, idArray, moveTo);
+        else if (evt.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+            BlockPos currentPos = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
+            if (currentPos == null) return;
+
+            if (minimapDragStartBp == null) {
+                minimapDragStartBp = currentPos;
+                FormationDragMove.startDrag(currentPos);
+            }
+
+            if (FormationDragMove.isDragging()) {
+                FormationDragMove.updateDrag(currentPos, UnitClientEvents.getSelectedUnits().size(), MC.level);
             }
         }
     }
@@ -1057,26 +1062,25 @@ public class MinimapClientEvents {
                     );
                 }
             }
+    }
         } else if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-            BlockPos moveTo = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
-            if (moveTo == null) {
-                return;
+            if (FormationDragMove.isDragging()) {
+                FormationDragMove.endDrag(UnitClientEvents.getSelectedUnits());
+                minimapDragStartBp = null;
+            } else {
+                BlockPos moveTo = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
+                if (moveTo == null) return;
+                if (altDown) {
+                    addMapMarkerForSelfAndAllies((int) evt.getMouseX(), (int) evt.getMouseY());
+                    evt.setCanceled(true);
+                    return;
+                }
+                if (!UnitClientEvents.getSelectedUnits().isEmpty()) {
+                    var ids = UnitClientEvents.getSelectedUnits();
+                    var idArray = ArrayUtil.livingEntityListToIdArray(ids);
+                    UnitClientEvents.sendUnitCommandManual(UnitAction.MOVE, -1, idArray, moveTo);
+                }
             }
-            if (altDown) {
-                addMapMarkerForSelfAndAllies((int) evt.getMouseX(), (int) evt.getMouseY());
-                evt.setCanceled(true);
-                return;
-            }
-            if (!UnitClientEvents.getSelectedUnits().isEmpty()) {
-                var ids = UnitClientEvents.getSelectedUnits();
-                var idArray = ArrayUtil.livingEntityListToIdArray(ids);
-                UnitClientEvents.sendUnitCommandManual(UnitAction.MOVE,
-                    -1,
-                    idArray,
-                    moveTo
-                );
-            }
-        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -1082,21 +1082,25 @@ public class MinimapClientEvents {
                     LivingEntity le = pair.getFirst();
                     BlockPos targetBp = pair.getSecond();
                     if (le instanceof Unit unit) {
-                        int[] singleUnitId = new int[]{le.getId()};
-                        new UnitActionItem(
-                            MC.player.getName().getString(),
-                            UnitAction.MOVE, -1, singleUnitId,
-                            targetBp,
-                            new BlockPos(0, 0, 0)
-                        ).action(MC.level);
-                        PacketHandler.INSTANCE.sendToServer(new UnitActionServerboundPacket(
-                            MC.player.getName().getString(),
-                            UnitAction.MOVE, -1, singleUnitId,
-                            targetBp,
-                            new BlockPos(0, 0, 0),
-                            Keybindings.shiftMod.isDown()
-                        ));
-                    }
+					int[] singleUnitId = new int[]{le.getId()};
+					boolean queueOrders = Keybindings.shiftMod.isDown();
+					if (!queueOrders) {
+						new UnitActionItem(
+							MC.player.getName().getString(),
+							UnitAction.MOVE, -1, singleUnitId,
+							targetBp,
+							new BlockPos(0, 0, 0)
+						).action(MC.level);
+					} else {
+						MiscUtil.addUnitCheckpoint(unit, targetBp, true);
+					}
+					PacketHandler.INSTANCE.sendToServer(new UnitActionServerboundPacket(
+						MC.player.getName().getString(),
+						UnitAction.MOVE, -1, singleUnitId,
+						targetBp,
+						new BlockPos(0, 0, 0),
+						queueOrders
+					));
                 }
                 minimapDragStartBp = null;
             } else {

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -1060,10 +1060,10 @@ public class MinimapClientEvents {
                         MC.player.getY(),
                         (double) moveTo.getZ()
                     );
-                }
             }
-    }
-        } else if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+            }
+        }
+        else if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
             if (FormationDragMove.isDragging()) {
                 FormationDragMove.endDrag(UnitClientEvents.getSelectedUnits());
                 minimapDragStartBp = null;
@@ -1081,6 +1081,7 @@ public class MinimapClientEvents {
                     UnitClientEvents.sendUnitCommandManual(UnitAction.MOVE, -1, idArray, moveTo);
                 }
             }
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -1102,6 +1102,7 @@ public class MinimapClientEvents {
 						queueOrders
 					));
                 }
+			}
                 minimapDragStartBp = null;
             } else {
                 BlockPos moveTo = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -106,6 +106,7 @@ public class MinimapClientEvents {
     // rate-limit teleporting from dragging the minimap to prevent being kicked from packet spamming
     private static long lastDragTeleportTimestamp = System.currentTimeMillis();
     private static BlockPos minimapDragStartBp = null;
+	private static boolean minimapRightClickDown = false;
 
     private static DynamicTexture mapTexture = new DynamicTexture(worldRadius * 2, worldRadius * 2, true);
     private static RenderType mapRenderType = RenderType.textSeeThrough(Minecraft.getInstance().textureManager.register(
@@ -1016,6 +1017,7 @@ public class MinimapClientEvents {
             }
         }
         else if (evt.getMouseButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+			if (!minimapRightClickDown) return;
             BlockPos currentPos = getWorldPosOnMinimap((float) evt.getMouseX(), (float) evt.getMouseY(), false);
             if (currentPos == null) return;
 
@@ -1065,6 +1067,9 @@ public class MinimapClientEvents {
             }
             }
         }
+		if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+			minimapRightClickDown = isPointInsideMinimap(evt.getMouseX(), evt.getMouseY());
+		}
     }
 
     @SubscribeEvent
@@ -1076,6 +1081,10 @@ public class MinimapClientEvents {
         }
 
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+		if (!minimapRightClickDown) {
+			minimapRightClickDown = false;
+			return;
+		}
             if (FormationDragMove.isDragging()) {
                 var pairs = FormationDragMove.endDrag(UnitClientEvents.getSelectedUnits());
                 for (var pair : pairs) {
@@ -1117,6 +1126,7 @@ public class MinimapClientEvents {
                     UnitClientEvents.sendUnitCommandManual(UnitAction.MOVE, -1, idArray, moveTo);
                 }
             }
+		minimapRightClickDown = false;
         }
     }
 

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -1068,7 +1068,7 @@ public class MinimapClientEvents {
             }
         }
 		if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-			minimapRightClickDown = isPointInsideMinimap(evt.getMouseX(), evt.getMouseY());
+			minimapRightClickDown = isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()) && !UnitClientEvents.getSelectedUnits().isEmpty();
 		}
     }
 

--- a/src/main/java/com/solegendary/reignofnether/orthoview/OrthoviewClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/orthoview/OrthoviewClientEvents.java
@@ -269,8 +269,14 @@ public class OrthoviewClientEvents {
         }
 
         long windowHandle = MC.getWindow().getWindow();
-        if (windowHandle == 0L) return;
-        int cursorMode = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
+        int cursorMode;
+
+        try {
+            cursorMode = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
+        } catch (NullPointerException | IllegalStateException e) {
+            cursorMode = GLFW.GLFW_CURSOR_NORMAL;
+        }
+        
         boolean grabbed = cursorMode == GLFW.GLFW_CURSOR_DISABLED;
         if (MC.screen == null && !grabbed && MC.isWindowActive()) {
             MC.mouseHandler.releaseMouse();

--- a/src/main/java/com/solegendary/reignofnether/orthoview/OrthoviewClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/orthoview/OrthoviewClientEvents.java
@@ -269,6 +269,7 @@ public class OrthoviewClientEvents {
         }
 
         long windowHandle = MC.getWindow().getWindow();
+        if (windowHandle == 0L) return;
         int cursorMode = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
         boolean grabbed = cursorMode == GLFW.GLFW_CURSOR_DISABLED;
         if (MC.screen == null && !grabbed && MC.isWindowActive()) {

--- a/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
@@ -1,0 +1,116 @@
+package com.solegendary.reignofnether.unit;
+
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FormationDragMove {
+
+    private static BlockPos dragStartBp = null;
+    private static BlockPos dragEndBp = null;
+    private static List<BlockPos> formationTargets = new ArrayList<>();
+    private static boolean dragging = false;
+
+    public static boolean isDragging() {
+        return dragging;
+    }
+
+    public static void startDrag(BlockPos bp) {
+        dragStartBp = bp;
+        dragEndBp = bp;
+        dragging = true;
+        formationTargets.clear();
+    }
+
+    public static void updateDrag(BlockPos currentBp, int unitCount, Level level) {
+        if (!dragging) return;
+        dragEndBp = currentBp;
+        calculateTargets(unitCount, level);
+    }
+
+    public static List<BlockPos> getFormationTargets() {
+        return formationTargets;
+    }
+
+    public static Vec3 getLineStart() {
+        if (dragStartBp == null) return Vec3.ZERO;
+        return new Vec3(dragStartBp.getX() + 0.5, dragStartBp.getY() + 1.0, dragStartBp.getZ() + 0.5);
+    }
+
+    public static Vec3 getLineEnd() {
+        if (dragEndBp == null) return Vec3.ZERO;
+        return new Vec3(dragEndBp.getX() + 0.5, dragEndBp.getY() + 1.0, dragEndBp.getZ() + 0.5);
+    }
+
+    public static List<Pair<LivingEntity, BlockPos>> endDrag(List<LivingEntity> units) {
+        List<Pair<LivingEntity, BlockPos>> result = assignUnitsToPositions(units);
+        dragStartBp = null;
+        dragEndBp = null;
+        formationTargets.clear();
+        dragging = false;
+        return result;
+    }
+
+    public static void cancelDrag() {
+        dragStartBp = null;
+        dragEndBp = null;
+        formationTargets.clear();
+        dragging = false;
+    }
+
+    private static void calculateTargets(int unitCount, Level level) {
+        formationTargets.clear();
+        if (dragStartBp == null || dragEndBp == null || unitCount <= 0) return;
+
+        if (unitCount == 1) {
+            formationTargets.add(getHeightAdjustedPos(level, dragEndBp));
+            return;
+        }
+
+        Vec3 start = Vec3.atCenterOf(dragStartBp);
+        Vec3 end = Vec3.atCenterOf(dragEndBp);
+
+        for (int i = 0; i < unitCount; i++) {
+            double t = (i + 0.5) / unitCount;
+            double x = start.x + (end.x - start.x) * t;
+            double z = start.z + (end.z - start.z) * t;
+            BlockPos bp = new BlockPos((int) Math.floor(x), dragStartBp.getY(), (int) Math.floor(z));
+            formationTargets.add(getHeightAdjustedPos(level, bp));
+        }
+    }
+
+    private static BlockPos getHeightAdjustedPos(Level level, BlockPos bp) {
+        int groundY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, bp.getX(), bp.getZ()) - 1;
+        return new BlockPos(bp.getX(), groundY, bp.getZ());
+    }
+
+    private static List<Pair<LivingEntity, BlockPos>> assignUnitsToPositions(List<LivingEntity> units) {
+        List<Pair<LivingEntity, BlockPos>> result = new ArrayList<>();
+        if (units.isEmpty() || formationTargets.isEmpty()) return result;
+
+        List<LivingEntity> unassigned = new ArrayList<>(units);
+
+        for (BlockPos target : formationTargets) {
+            LivingEntity closest = null;
+            double closestDist = Double.MAX_VALUE;
+            for (LivingEntity unit : unassigned) {
+                double dist = unit.getOnPos().distSqr(target);
+                if (dist < closestDist) {
+                    closestDist = dist;
+                    closest = unit;
+                }
+            }
+            if (closest != null) {
+                result.add(new Pair<>(closest, target));
+                unassigned.remove(closest);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
@@ -1,11 +1,10 @@
 package com.solegendary.reignofnether.unit;
 
 import com.mojang.datafixers.util.Pair;
+import com.solegendary.reignofnether.util.MiscUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.LeavesBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.Vec3;
 
@@ -88,12 +87,14 @@ public class FormationDragMove {
     }
 
     private static BlockPos getHeightAdjustedPos(Level level, BlockPos bp) {
-        int groundY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, bp.getX(), bp.getZ()) - 1;
-        while (groundY > level.getMinBuildHeight() && level.getBlockState(new BlockPos(bp.getX(), groundY, bp.getZ())).getBlock() instanceof LeavesBlock) {
-            groundY--;
-        }
-        return new BlockPos(bp.getX(), groundY, bp.getZ());
-    }
+		int groundY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, bp.getX(), bp.getZ()) - 1;
+		BlockPos checkBp = new BlockPos(bp.getX(), groundY, bp.getZ());
+		while (groundY > level.getMinBuildHeight() && !MiscUtil.isSolidBlocking(level, checkBp) && level.getBlockState(checkBp).getFluidState().isEmpty()) {
+			groundY--;
+			checkBp = new BlockPos(bp.getX(), groundY, bp.getZ());
+		}
+		return new BlockPos(bp.getX(), groundY, bp.getZ());
+	}
 
     private static List<Pair<LivingEntity, BlockPos>> assignUnitsToPositions(List<LivingEntity> units) {
         List<Pair<LivingEntity, BlockPos>> result = new ArrayList<>();

--- a/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
@@ -4,6 +4,8 @@ import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.Vec3;
 
@@ -87,6 +89,9 @@ public class FormationDragMove {
 
     private static BlockPos getHeightAdjustedPos(Level level, BlockPos bp) {
         int groundY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, bp.getX(), bp.getZ()) - 1;
+        while (groundY > level.getMinBuildHeight() && level.getBlockState(new BlockPos(bp.getX(), groundY, bp.getZ())).getBlock() instanceof LeavesBlock) {
+            groundY--;
+        }
         return new BlockPos(bp.getX(), groundY, bp.getZ());
     }
 

--- a/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/FormationDragMove.java
@@ -1,5 +1,7 @@
 package com.solegendary.reignofnether.unit;
 
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockState;
 import com.mojang.datafixers.util.Pair;
 import com.solegendary.reignofnether.util.MiscUtil;
 import net.minecraft.core.BlockPos;
@@ -86,10 +88,14 @@ public class FormationDragMove {
         }
     }
 
-    private static BlockPos getHeightAdjustedPos(Level level, BlockPos bp) {
+	private static BlockPos getHeightAdjustedPos(Level level, BlockPos bp) {
 		int groundY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, bp.getX(), bp.getZ()) - 1;
 		BlockPos checkBp = new BlockPos(bp.getX(), groundY, bp.getZ());
-		while (groundY > level.getMinBuildHeight() && !MiscUtil.isSolidBlocking(level, checkBp) && level.getBlockState(checkBp).getFluidState().isEmpty()) {
+		while (groundY > level.getMinBuildHeight()) {
+			BlockState bs = level.getBlockState(checkBp);
+			boolean isLeaves = bs.getBlock() instanceof LeavesBlock;
+			boolean isPassable = !MiscUtil.isSolidBlocking(level, checkBp) && bs.getFluidState().isEmpty();
+			if (!isLeaves && !isPassable) break;
 			groundY--;
 			checkBp = new BlockPos(bp.getX(), groundY, bp.getZ());
 		}

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -858,7 +858,7 @@ rightClickActionTaken = true;
             return;
 
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-		if (MinimapClientEvents.isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()))
+		if (MinimapClientEvents.isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()) && !FormationDragMove.isDragging())
 			return;
             if (Keybindings.altMod.isDown() && FormationDragMove.isDragging()) {
                 FormationDragMove.cancelDrag();

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -890,7 +890,7 @@ rightClickActionTaken = true;
         for (var pair : pairs) {
             LivingEntity le = pair.getFirst();
             BlockPos targetBp = pair.getSecond();
-            if (le instanceof Unit) {
+            if (le instanceof Unit unit) {
                 int[] singleUnitId = new int[]{le.getId()};
 
                 if (!queueOrders) {
@@ -900,6 +900,8 @@ rightClickActionTaken = true;
                         targetBp,
                         new BlockPos(0, 0, 0)
                     ).action(MC.level);
+                } else {
+                    MiscUtil.addUnitCheckpoint(unit, targetBp, true);
                 }
 
                 PacketHandler.INSTANCE.sendToServer(new UnitActionServerboundPacket(

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -373,6 +373,14 @@ public class UnitClientEvents {
         doResolveMoveAction();
     }
 
+    private static void resolveMoveActionDeferred() {
+        if (!selectedUnits.isEmpty()) {
+            rightClickMoveDeferred = true;
+            return;
+        }
+        doResolveMoveAction();
+    }
+
     private static void doResolveMoveAction() {
         // follow friendly unit
         if (preselectedUnits.size() == 1 && !targetingSelf()) {
@@ -787,11 +795,11 @@ public class UnitClientEvents {
                     else if (BuildingUtils.isBuildingBuildable(true, preSelBuilding))
                         sendUnitCommand(UnitAction.BUILD_REPAIR);
                     else
-                        resolveMoveAction();
+                        resolveMoveActionDeferred();
                 }
                 // right click -> follow friendly unit or go to preselected blockPos
                 else
-                    resolveMoveAction();
+                    resolveMoveActionDeferred();
             }
         }
         // clear all cursor actions
@@ -802,6 +810,9 @@ public class UnitClientEvents {
     @SubscribeEvent
     public static void onMouseDrag(ScreenEvent.MouseDragged.Pre evt) {
         if (!OrthoviewClientEvents.isEnabled() || MC.level == null)
+            return;
+
+        if (Keybindings.altMod.isDown())
             return;
 
         if (!CursorClientEvents.isRightDragActive())
@@ -837,6 +848,9 @@ public class UnitClientEvents {
             return;
 
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+            if (Keybindings.altMod.isDown() && FormationDragMove.isDragging()) {
+                FormationDragMove.cancelDrag();
+            }
             boolean wasFormationDrag = FormationDragMove.isDragging();
             if (wasFormationDrag) {
                 ArrayList<LivingEntity> selUnits = getSelectedUnits();
@@ -848,7 +862,7 @@ public class UnitClientEvents {
                         actionableUnits.add(unit);
                     }
                 }
-                resolveFormationMove(actionableUnits);
+                resolveFormationMove(actionableUnits, Keybindings.shiftMod.isDown());
             }
             if (rightClickMoveDeferred) {
                 rightClickMoveDeferred = false;
@@ -859,7 +873,7 @@ public class UnitClientEvents {
         }
     }
 
-    private static void resolveFormationMove(ArrayList<LivingEntity> units) {
+    private static void resolveFormationMove(ArrayList<LivingEntity> units, boolean queueOrders) {
         if (MC.player == null || MC.level == null) return;
 
         List<com.mojang.datafixers.util.Pair<LivingEntity, BlockPos>> pairs = FormationDragMove.endDrag(units);
@@ -871,19 +885,21 @@ public class UnitClientEvents {
             if (le instanceof Unit) {
                 int[] singleUnitId = new int[]{le.getId()};
 
-                new UnitActionItem(
-                    playerName,
-                    UnitAction.MOVE, -1, singleUnitId,
-                    targetBp,
-                    new BlockPos(0, 0, 0)
-                ).action(MC.level);
+                if (!queueOrders) {
+                    new UnitActionItem(
+                        playerName,
+                        UnitAction.MOVE, -1, singleUnitId,
+                        targetBp,
+                        new BlockPos(0, 0, 0)
+                    ).action(MC.level);
+                }
 
                 PacketHandler.INSTANCE.sendToServer(new UnitActionServerboundPacket(
                     playerName,
                     UnitAction.MOVE, -1, singleUnitId,
                     targetBp,
                     new BlockPos(0, 0, 0),
-                    false
+                    queueOrders
                 ));
             }
         }

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -158,6 +158,7 @@ public class UnitClientEvents {
     }
 
     private static boolean rightClickMoveDeferred = false;
+    private static boolean rightClickActionTaken = false;
 
     public static void addPreselectedUnit(LivingEntity unit) {
         if (unit instanceof Player player && (player.isSpectator() || player.isCreative()))
@@ -735,6 +736,7 @@ public class UnitClientEvents {
                 BuildingClientEvents.setBuildingToPlace(null);
                 return;
             }
+rightClickActionTaken = false;
             if (!selectedUnits.isEmpty()) {
                 BuildingPlacement preSelBuilding = BuildingClientEvents.getPreselectedBuilding();
 
@@ -767,6 +769,7 @@ public class UnitClientEvents {
                      } else {
                          sendUnitCommand(UnitAction.ATTACK);
                      }
+rightClickActionTaken = true;
                 }
                 // right click -> attack unfriendly building
                 else if (hudSelectedEntity instanceof AttackerUnit &&
@@ -776,6 +779,7 @@ public class UnitClientEvents {
                         ((GameruleClient.neutralAggro && getPlayerToBuildingRelationship(preSelBuilding) == Relationship.NEUTRAL) ||
                         getPlayerToBuildingRelationship(preSelBuilding) == Relationship.HOSTILE)) {
                     sendUnitCommand(UnitAction.ATTACK_BUILDING);
+rightClickActionTaken = true;
                 }
                 // right click -> return resources
                 else if (hudSelectedEntity instanceof Unit unit &&
@@ -816,6 +820,10 @@ public class UnitClientEvents {
             return;
 
         if (!CursorClientEvents.isRightDragActive())
+            return;
+
+        // don't allow formation drag if an attack command was issued on right-click press
+        if (rightClickActionTaken)
             return;
 
         ArrayList<LivingEntity> selUnits = getSelectedUnits();

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -736,6 +736,8 @@ public class UnitClientEvents {
                 BuildingClientEvents.setBuildingToPlace(null);
                 return;
             }
+			if (MinimapClientEvents.isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()))
+				return;
 rightClickActionTaken = false;
             if (!selectedUnits.isEmpty()) {
                 BuildingPlacement preSelBuilding = BuildingClientEvents.getPreselectedBuilding();
@@ -856,6 +858,8 @@ rightClickActionTaken = true;
             return;
 
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+		if (MinimapClientEvents.isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()))
+			return;
             if (Keybindings.altMod.isDown() && FormationDragMove.isDragging()) {
                 FormationDragMove.cancelDrag();
             }

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -858,7 +858,7 @@ rightClickActionTaken = true;
             return;
 
         if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
-		if (MinimapClientEvents.isPointInsideMinimap(evt.getMouseX(), evt.getMouseY()) && !FormationDragMove.isDragging())
+		if (MinimapClientEvents.minimapRightClickDown)
 			return;
             if (Keybindings.altMod.isDown() && FormationDragMove.isDragging()) {
                 FormationDragMove.cancelDrag();

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -889,6 +889,8 @@ public class UnitClientEvents {
         }
     }
 
+    public static RenderLevelStageEvent.Stage stage = AFTER_ENTITIES;
+
     @SubscribeEvent
     public static void onRenderLevel(RenderLevelStageEvent evt) {
         if (MC.level == null)

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -157,6 +157,8 @@ public class UnitClientEvents {
         return allUnits;
     }
 
+    private static boolean rightClickMoveDeferred = false;
+
     public static void addPreselectedUnit(LivingEntity unit) {
         if (unit instanceof Player player && (player.isSpectator() || player.isCreative()))
             return;
@@ -364,6 +366,14 @@ public class UnitClientEvents {
     }
 
     private static void resolveMoveAction() {
+        if (CursorClientEvents.isRightDragCouldStart() && !selectedUnits.isEmpty()) {
+            rightClickMoveDeferred = true;
+            return;
+        }
+        doResolveMoveAction();
+    }
+
+    private static void doResolveMoveAction() {
         // follow friendly unit
         if (preselectedUnits.size() == 1 && !targetingSelf()) {
             if (hudSelectedEntity instanceof WitchUnit witchUnit) {
@@ -789,7 +799,95 @@ public class UnitClientEvents {
         markSelectedUnitsChanged();
     }
 
-    public static RenderLevelStageEvent.Stage stage = AFTER_ENTITIES;
+    @SubscribeEvent
+    public static void onMouseDrag(ScreenEvent.MouseDragged.Pre evt) {
+        if (!OrthoviewClientEvents.isEnabled() || MC.level == null)
+            return;
+
+        if (!CursorClientEvents.isRightDragActive())
+            return;
+
+        ArrayList<LivingEntity> selUnits = getSelectedUnits();
+        if (selUnits.isEmpty())
+            return;
+
+        BlockPos currentBp = CursorClientEvents.getPreselectedBlockPos();
+        ArrayList<LivingEntity> actionableUnits = new ArrayList<>();
+        for (LivingEntity unit : selUnits) {
+            if ((getPlayerToEntityRelationship(unit) == Relationship.OWNED ||
+                    NonUnitClientEvents.canControlAllMobs() ||
+                    AlliancesClient.canControlAlly(unit)) && unit instanceof Unit) {
+                actionableUnits.add(unit);
+            }
+        }
+
+        if (actionableUnits.isEmpty())
+            return;
+
+        if (!FormationDragMove.isDragging()) {
+            FormationDragMove.startDrag(CursorClientEvents.getRightClickStartBp());
+        }
+
+        FormationDragMove.updateDrag(currentBp, actionableUnits.size(), MC.level);
+    }
+
+    @SubscribeEvent
+    public static void onMouseRelease(ScreenEvent.MouseButtonReleased.Post evt) {
+        if (!OrthoviewClientEvents.isEnabled() || MC.level == null)
+            return;
+
+        if (evt.getButton() == GLFW.GLFW_MOUSE_BUTTON_2) {
+            boolean wasFormationDrag = FormationDragMove.isDragging();
+            if (wasFormationDrag) {
+                ArrayList<LivingEntity> selUnits = getSelectedUnits();
+                ArrayList<LivingEntity> actionableUnits = new ArrayList<>();
+                for (LivingEntity unit : selUnits) {
+                    if ((getPlayerToEntityRelationship(unit) == Relationship.OWNED ||
+                            NonUnitClientEvents.canControlAllMobs() ||
+                            AlliancesClient.canControlAlly(unit)) && unit instanceof Unit) {
+                        actionableUnits.add(unit);
+                    }
+                }
+                resolveFormationMove(actionableUnits);
+            }
+            if (rightClickMoveDeferred) {
+                rightClickMoveDeferred = false;
+                if (!wasFormationDrag) {
+                    doResolveMoveAction();
+                }
+            }
+        }
+    }
+
+    private static void resolveFormationMove(ArrayList<LivingEntity> units) {
+        if (MC.player == null || MC.level == null) return;
+
+        List<com.mojang.datafixers.util.Pair<LivingEntity, BlockPos>> pairs = FormationDragMove.endDrag(units);
+        String playerName = MC.player.getName().getString();
+
+        for (var pair : pairs) {
+            LivingEntity le = pair.getFirst();
+            BlockPos targetBp = pair.getSecond();
+            if (le instanceof Unit) {
+                int[] singleUnitId = new int[]{le.getId()};
+
+                new UnitActionItem(
+                    playerName,
+                    UnitAction.MOVE, -1, singleUnitId,
+                    targetBp,
+                    new BlockPos(0, 0, 0)
+                ).action(MC.level);
+
+                PacketHandler.INSTANCE.sendToServer(new UnitActionServerboundPacket(
+                    playerName,
+                    UnitAction.MOVE, -1, singleUnitId,
+                    targetBp,
+                    new BlockPos(0, 0, 0),
+                    false
+                ));
+            }
+        }
+    }
 
     @SubscribeEvent
     public static void onRenderLevel(RenderLevelStageEvent evt) {
@@ -963,6 +1061,36 @@ public class UnitClientEvents {
                         }
                     }
                      */
+                }
+            }
+
+            if (FormationDragMove.isDragging()) {
+                VertexConsumer vertexConsumerLineFd = MC.renderBuffers().bufferSource().getBuffer(RenderType.LINES);
+                VertexConsumer vertexConsumerEntityTranslucentFd = MC.renderBuffers().bufferSource().getBuffer(RenderType.entityTranslucent(ResourceLocation.parse("forge:textures/white.png")));
+                float a = 0.5f;
+
+                Vec3 lineStart = FormationDragMove.getLineStart();
+                Vec3 lineEnd = FormationDragMove.getLineEnd();
+                MyRenderer.drawLine(evt.getPoseStack(), vertexConsumerLineFd, lineStart, lineEnd, 0, 1, 0, a);
+
+                for (BlockPos bp : FormationDragMove.getFormationTargets()) {
+                    if (MC.level.getBlockState(bp.offset(0, 1, 0)).getBlock() instanceof SnowLayerBlock) {
+                        AABB aabb = new AABB(bp);
+                        aabb = aabb.setMaxY(aabb.maxY + 0.13f);
+                        MyRenderer.drawSolidBox(
+                                evt.getPoseStack(),
+                                vertexConsumerEntityTranslucentFd,
+                                aabb,
+                                Direction.UP,
+                                0,
+                                1,
+                                0,
+                                a,
+                                ResourceLocation.parse("forge:textures/white.png")
+                        );
+                    } else {
+                        MyRenderer.drawBlockFace(evt.getPoseStack(), vertexConsumerEntityTranslucentFd, Direction.UP, bp, 0, 1, 0, a);
+                    }
                 }
             }
         }


### PR DESCRIPTION
feat: implement Formation Drag-Move system for unit management + fix the crash on mobile devices (in launchers like Pojav launcher)

# How to test
1. Select a group of units (e.g., Zombies).
2. Right-click and drag on the ground.
3. Observe the visual markers and how units distribute themselves along the line upon release.

# Known issues
None

Screenshots:
<img width="2400" height="1080" alt="2026-05-07_11 58 34" src="https://github.com/user-attachments/assets/16d627e0-acca-4a90-b8f1-948000f00d5a" />
<img width="2400" height="1080" alt="2026-05-07_11 59 15" src="https://github.com/user-attachments/assets/faaec8ce-b9ac-4ab2-8e08-7b0eef2ccb71" />
