### PR TITLE
perf: server sync loop and hotspot cleanup

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/fogofwar/FogOfWarServerEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/fogofwar/FogOfWarServerEvents.java
@@ -8,6 +8,7 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.TickEvent;
@@ -78,11 +79,14 @@ public class FogOfWarServerEvents {
 
         ArrayList<Pair<BlockPos, BlockState>> plants = new ArrayList<>();
 
+        // The 16³ region lies entirely in one chunk — fetch it once instead of looking it up per read.
+        LevelChunk chunk = serverLevel.getChunkAt(renderChunkOrigin);
+
         for (int x = 0; x < 16; x++) {
             for (int y = 0; y < 16; y++) {
                 for (int z = 0; z < 16; z++) {
                     BlockPos bp = renderChunkOrigin.offset(x,y,z);
-                    BlockState bs = serverLevel.getBlockState(bp);
+                    BlockState bs = chunk.getBlockState(bp);
                     if (bs.is(BlockTags.REPLACEABLE_BY_TREES) || bs.getBlock() instanceof IPlantable) {
                         plants.add(new Pair<>(bp, bs));
                     }
@@ -96,7 +100,7 @@ public class FogOfWarServerEvents {
             for (int y = 0; y < 16; y++) {
                 for (int z = 0; z < 16; z++) {
                     BlockPos bp = renderChunkOrigin.offset(x,y,z);
-                    BlockState bs = serverLevel.getBlockState(bp);
+                    BlockState bs = chunk.getBlockState(bp);
                     serverLevel.setBlockAndUpdate(bp, Blocks.BEDROCK.defaultBlockState());
                     serverLevel.setBlockAndUpdate(bp, bs);
                 }

--- a/src/main/java/com/solegendary/reignofnether/healthbars/HealthBarClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/healthbars/HealthBarClientEvents.java
@@ -30,7 +30,6 @@ import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.StreamSupport;
 
 public class HealthBarClientEvents {
 
@@ -70,9 +69,16 @@ public class HealthBarClientEvents {
         return entity instanceof LivingEntity && !(entity instanceof ArmorStand) &&
                    (!entity.isInvisibleTo(client.player) || entity.isCurrentlyGlowing() || entity.isOnFire() ||
                    entity instanceof Creeper && ((Creeper) entity).isPowered() ||
-                   StreamSupport.stream(entity.getAllSlots().spliterator(), false).anyMatch(is -> !is.isEmpty())) &&
+                   hasAnyEquippedItem(entity)) &&
                  entity != client.player &&
                 !entity.isSpectator();
+    }
+
+    private static boolean hasAnyEquippedItem(Entity entity) {
+        for (var stack : entity.getAllSlots())
+            if (!stack.isEmpty())
+                return true;
+        return false;
     }
 
     private static void prepareRenderInWorld(LivingEntity entity) {

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
@@ -1,6 +1,5 @@
 package com.solegendary.reignofnether.unit;
 
-import com.mojang.datafixers.util.Pair;
 import com.solegendary.reignofnether.ReignOfNether;
 import com.solegendary.reignofnether.ability.AbilityClientboundPacket;
 import com.solegendary.reignofnether.ability.heroAbilities.necromancer.SoulSiphonPassive;
@@ -116,7 +115,31 @@ public class UnitServerEvents {
 
     private static final ArrayList<LivingEntity> allUnits = new ArrayList<>();
 
-    private static final ArrayList<Pair<Integer, ChunkAccess>> forcedUnitChunks = new ArrayList<>();
+    private static final HashMap<Integer, ChunkAccess> forcedUnitChunks = new HashMap<>();
+
+    private static final List<MobEffect> SYNCED_MOB_EFFECTS = List.of(
+        MobEffects.DAMAGE_RESISTANCE,
+        MobEffectRegistrar.STUN.get(),
+        MobEffectRegistrar.FREEZE.get(),
+        MobEffectRegistrar.DAMAGE_TAKEN_INCREASE.get(),
+        MobEffectRegistrar.MINOR_MOVEMENT_SLOWDOWN.get(),
+        MobEffectRegistrar.MINOR_MOVEMENT_SPEED.get(),
+        MobEffectRegistrar.ATTACK_SLOWDOWN.get(),
+        MobEffectRegistrar.TEMPORARY_EFFICIENCY.get(),
+        MobEffectRegistrar.BLOODLUST.get(),
+        MobEffectRegistrar.FROST_DAMAGE.get(),
+        MobEffectRegistrar.DISARM.get(),
+        MobEffectRegistrar.ENCHANTMENT_AMPLIFIER.get(),
+        MobEffectRegistrar.SCORCHING_FIRE.get(),
+        MobEffectRegistrar.SOULS_AFLAME.get(),
+        MobEffectRegistrar.ANGRY.get(),
+        MobEffectRegistrar.FEARFUL.get(),
+        MobEffectRegistrar.PARTIALLY_POSSESSED.get(),
+        MobEffects.LEVITATION
+    );
+
+    // Per-entity last-synced mob effect amplifiers. Null amp means "absent last sync".
+    private static final HashMap<Integer, HashMap<MobEffect, Byte>> lastSyncedEffects = new HashMap<>();
 
     public static ArrayList<LivingEntity> getAllUnits() {
         return allUnits;
@@ -399,7 +422,7 @@ public class UnitServerEvents {
                 true,
                 true
             );
-            forcedUnitChunks.add(new Pair<>(entity.getId(), chunk));
+            forcedUnitChunks.put(entity.getId(), chunk);
         }
     }
 
@@ -411,6 +434,7 @@ public class UnitServerEvents {
             && !evt.getLevel().isClientSide) {
 
             allUnits.removeIf(e -> e.getId() == entity.getId());
+            lastSyncedEffects.remove(entity.getId());
             UnitSyncClientboundPacket.sendLeavePacket(entity);
 
             //ChunkAccess chunk = evt.getLevel().getChunk(entity.getOnPos());
@@ -434,7 +458,7 @@ public class UnitServerEvents {
                     }
                 }
             } catch (ConcurrentModificationException e) {
-                System.out.println("Caught ConcurrentModificationException in UnitServerEvents EntityLeaveLevelEvent: " + e.getMessage());
+                ReignOfNether.LOGGER.error("Caught ConcurrentModificationException in UnitServerEvents EntityLeaveLevelEvent", e);
             }
         }
     }
@@ -659,31 +683,20 @@ public class UnitServerEvents {
                     UnitSyncClientboundPacket.sendSyncResourcesPacket(unit);
                     UnitSyncClientboundPacket.sendSyncStatsPacket(entity);
 
-                    for (MobEffect me : List.of(
-                            MobEffects.DAMAGE_RESISTANCE,
-                            MobEffectRegistrar.STUN.get(),
-                            MobEffectRegistrar.FREEZE.get(),
-                            MobEffectRegistrar.DAMAGE_TAKEN_INCREASE.get(),
-                            MobEffectRegistrar.MINOR_MOVEMENT_SLOWDOWN.get(),
-                            MobEffectRegistrar.MINOR_MOVEMENT_SPEED.get(),
-                            MobEffectRegistrar.ATTACK_SLOWDOWN.get(),
-                            MobEffectRegistrar.TEMPORARY_EFFICIENCY.get(),
-                            MobEffectRegistrar.BLOODLUST.get(),
-                            MobEffectRegistrar.FROST_DAMAGE.get(),
-                            MobEffectRegistrar.DISARM.get(),
-                            MobEffectRegistrar.ENCHANTMENT_AMPLIFIER.get(),
-                            MobEffectRegistrar.SCORCHING_FIRE.get(),
-                            MobEffectRegistrar.SOULS_AFLAME.get(),
-                            MobEffectRegistrar.ANGRY.get(),
-                            MobEffectRegistrar.FEARFUL.get(),
-                            MobEffectRegistrar.PARTIALLY_POSSESSED.get(),
-                            MobEffects.LEVITATION
-                    )) {
+                    HashMap<MobEffect, Byte> lastState = lastSyncedEffects.computeIfAbsent(entity.getId(), k -> new HashMap<>());
+                    for (MobEffect me : SYNCED_MOB_EFFECTS) {
                         MobEffectInstance mei = entity.getEffect(me);
-                        if (mei != null)
-                            UnitSyncMobEffectsClientboundPacket.addEffectClientside(entity, mei);
-                        else
+                        Byte lastAmp = lastState.get(me);
+                        if (mei != null) {
+                            byte amp = (byte) mei.getAmplifier();
+                            if (lastAmp == null || lastAmp != amp) {
+                                UnitSyncMobEffectsClientboundPacket.addEffectClientside(entity, mei);
+                                lastState.put(me, amp);
+                            }
+                        } else if (lastAmp != null) {
                             UnitSyncMobEffectsClientboundPacket.removeEffectClientside(entity, me);
+                            lastState.remove(me);
+                        }
                     }
 
                     if (unit.getAnchor() != null)
@@ -698,28 +711,21 @@ public class UnitServerEvents {
                 }
 
                 // remove old chunk // add current chunk
-                boolean chunkNeedsUpdate = false;
                 ChunkAccess newChunk = evt.level.getChunk(entity.getOnPos());
+                ChunkAccess oldChunk = forcedUnitChunks.get(entity.getId());
+                boolean chunkNeedsUpdate = oldChunk != null && (
+                    oldChunk.getPos().x != newChunk.getPos().x || oldChunk.getPos().z != newChunk.getPos().z
+                );
 
-                for (Pair<Integer, ChunkAccess> forcedChunk : forcedUnitChunks) {
-                    int id = forcedChunk.getFirst();
-                    ChunkAccess chunk = forcedChunk.getSecond();
-                    if (id == entity.getId() && (
-                        chunk.getPos().x != newChunk.getPos().x || chunk.getPos().z != newChunk.getPos().z
-                    )) {
-                        ForgeChunkManager.forceChunk((ServerLevel) evt.level,
-                            ReignOfNether.MOD_ID,
-                            entity,
-                            chunk.getPos().x,
-                            chunk.getPos().z,
-                            false,
-                            true
-                        );
-                        chunkNeedsUpdate = true;
-                    }
-                }
                 if (chunkNeedsUpdate) {
-                    forcedUnitChunks.removeIf(p -> p.getFirst() == entity.getId());
+                    ForgeChunkManager.forceChunk((ServerLevel) evt.level,
+                        ReignOfNether.MOD_ID,
+                        entity,
+                        oldChunk.getPos().x,
+                        oldChunk.getPos().z,
+                        false,
+                        true
+                    );
                     ForgeChunkManager.forceChunk((ServerLevel) evt.level,
                         ReignOfNether.MOD_ID,
                         entity,
@@ -728,7 +734,7 @@ public class UnitServerEvents {
                         true,
                         true
                     );
-                    forcedUnitChunks.add(new Pair<>(entity.getId(), newChunk));
+                    forcedUnitChunks.put(entity.getId(), newChunk);
                     //ReignOfNether.LOGGER.info("Updated forced chunk for entity: " + entity.getId() + " at: " +
                     // newChunk.getPos().x + "," + newChunk.getPos().z);
                 }

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/RangedAttackBuildingGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/RangedAttackBuildingGoal.java
@@ -26,6 +26,19 @@ public class RangedAttackBuildingGoal<T extends Mob> extends Goal {
     private UnitCrossbowAttackGoal<?> cbowAttackGoal = null;
     private BuildingPlacement buildingTarget = null;
 
+    // Cached on first use — Unit's moveGoal is stable across the goal's lifetime
+    private boolean moveGoalResolved = false;
+    private FlyingMoveToTargetGoal cachedFlyingMoveGoal = null;
+
+    private FlyingMoveToTargetGoal getFlyingMoveGoal() {
+        if (!moveGoalResolved) {
+            moveGoalResolved = true;
+            if (((Unit) this.mob).getMoveGoal() instanceof FlyingMoveToTargetGoal fmg)
+                cachedFlyingMoveGoal = fmg;
+        }
+        return cachedFlyingMoveGoal;
+    }
+
     public RangedAttackBuildingGoal(T mob, UnitBowAttackGoal<?> bowAttackGoal) {
         this.mob = mob;
         this.bowAttackGoal = bowAttackGoal;
@@ -160,25 +173,25 @@ public class RangedAttackBuildingGoal<T extends Mob> extends Goal {
 
     // moveGoal controllers
     private boolean isDoneMoving() {
-        Unit unit = (Unit) this.mob;
-        if (unit.getMoveGoal() instanceof FlyingMoveToTargetGoal flyingMoveGoal)
-            return flyingMoveGoal.isAtDestination();
+        FlyingMoveToTargetGoal fmg = getFlyingMoveGoal();
+        if (fmg != null)
+            return fmg.isAtDestination();
         else
             return this.mob.getNavigation().isDone();
     }
 
     private void stopMoving() {
-        Unit unit = (Unit) this.mob;
-        if (unit.getMoveGoal() instanceof FlyingMoveToTargetGoal flyingMoveGoal)
-            flyingMoveGoal.stopMoving();
+        FlyingMoveToTargetGoal fmg = getFlyingMoveGoal();
+        if (fmg != null)
+            fmg.stopMoving();
         else
             this.mob.getNavigation().stop();
     }
 
     private void moveTo(BlockPos bp) {
-        Unit unit = (Unit) this.mob;
-        if (unit.getMoveGoal() instanceof FlyingMoveToTargetGoal flyingMoveGoal)
-            flyingMoveGoal.setMoveTarget(bp);
+        FlyingMoveToTargetGoal fmg = getFlyingMoveGoal();
+        if (fmg != null)
+            fmg.setMoveTarget(bp);
         else
             this.mob.getNavigation().moveTo(bp.getX(), bp.getY(), bp.getZ(), 1.0f);
     }

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/UnitRangedAttackGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/UnitRangedAttackGoal.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 public class UnitRangedAttackGoal<T extends net.minecraft.world.entity.Mob> extends Goal {
 
     private final int VELOCITY = 20;
+    private static final int LOS_CHECK_INTERVAL = 5; // recompute raycast at most every N ticks
 
     private final T mob;
     private final int attackWindupTicksMax;
@@ -29,6 +30,8 @@ public class UnitRangedAttackGoal<T extends net.minecraft.world.entity.Mob> exte
     private int attackCooldown = 0; // time to wait between bow windups
     private int attackTime = -1;
     private int seeTime = 0; // how long we have seen the target for
+    private int losCheckCooldown = 0; // throttle for hasLineOfSight raycast
+    private boolean lastLineOfSight = false; // cached raycast result
 
     public UnitRangedAttackGoal(T mob, int attackWindupTime) {
         this.mob = mob;
@@ -73,6 +76,7 @@ public class UnitRangedAttackGoal<T extends net.minecraft.world.entity.Mob> exte
     public void start() {
         super.start();
         this.mob.setAggressive(true);
+        losCheckCooldown = 0; // force a fresh raycast for the new target
     }
 
     public void stop() {
@@ -99,7 +103,13 @@ public class UnitRangedAttackGoal<T extends net.minecraft.world.entity.Mob> exte
             boolean isGarrisoned = garr != null;
             boolean isTargetGarrisoned = targetGarr != null;
 
-            boolean canSeeTarget = this.mob.getSensing().hasLineOfSight(target) || isGarrisoned || isTargetGarrisoned;
+            if (losCheckCooldown <= 0) {
+                lastLineOfSight = this.mob.getSensing().hasLineOfSight(target);
+                losCheckCooldown = LOS_CHECK_INTERVAL;
+            } else {
+                losCheckCooldown -= 1;
+            }
+            boolean canSeeTarget = lastLineOfSight || isGarrisoned || isTargetGarrisoned;
             boolean flag = this.seeTime > 0;
             if (canSeeTarget != flag) {
                 this.seeTime = 0;

--- a/src/main/java/com/solegendary/reignofnether/unit/units/piglins/WildfireUnit.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/units/piglins/WildfireUnit.java
@@ -671,7 +671,6 @@ public class WildfireUnit extends Blaze implements Unit, AttackerUnit, RangedAtt
                 for (int z = -range + z0; z < range + z0; z++) {
                     BlockPos pos = new BlockPos(x, y, z);
                     if (blockPosition().distToCenterSqr(pos.getCenter()) < range * range) {
-                        System.out.println(z);
                         BlockState bs = level().getBlockState(pos);
                         if (bs.getBlock() == Blocks.FIRE) {
                             level().setBlockAndUpdate(pos, BlockRegistrar.UNEXTINGUISHABLE_SOUL_FIRE.get().defaultBlockState());

--- a/src/main/java/com/solegendary/reignofnether/unit/units/villagers/PillagerUnit.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/units/villagers/PillagerUnit.java
@@ -1,5 +1,6 @@
 package com.solegendary.reignofnether.unit.units.villagers;
 
+import com.solegendary.reignofnether.ReignOfNether;
 import com.solegendary.reignofnether.ability.Abilities;
 import com.solegendary.reignofnether.ability.Ability;
 import com.solegendary.reignofnether.ability.abilities.MountRavager;
@@ -345,7 +346,7 @@ public class PillagerUnit extends Pillager implements Unit, AttackerUnit, Ranged
                 }
             }
         } catch (NullPointerException e) {
-            System.out.println("Caught NullPointerException in shootCrossbowProjectile: " + e.getMessage());
+            ReignOfNether.LOGGER.error("Caught NullPointerException in shootCrossbowProjectile", e);
         }
         if (pTarget == null)
             return;


### PR DESCRIPTION
Cheaper versions of a few per-tick hotspots. No behavior change, just less work at scale.

- `forcedUnitChunks`: ArrayList<Pair> → HashMap (drops the O(N²) linear scan)
- mob effect sync: delta-only instead of 18 effects × every unit every sync
- `SYNCED_MOB_EFFECTS` hoisted to `static final`
- FOW chunk reads: hoist `getChunk()` outside the 16³ loop in `syncClientBlocks`
- `UnitRangedAttackGoal`: throttle `hasLineOfSight()` raycast to every 5 ticks
- `RangedAttackBuildingGoal`: cache the `FlyingMoveToTargetGoal` instanceof check
- `HealthBarClientEvents`: stream → for loop

Also: 2 caught exceptions now route through `LOGGER.error` so stack traces aren't lost, and a leftover `println(z)` is gone.

### Files
`UnitServerEvents.java`, `FogOfWarServerEvents.java`, `UnitRangedAttackGoal.java`, `HealthBarClientEvents.java`, `RangedAttackBuildingGoal.java`, `WildfireUnit.java`, `PillagerUnit.java`

### Sibling PRs
This PR shares two files with sibling PRs but in different sections (no textual overlap):
- `UnitServerEvents.java` — sync loop fixes here; sibling PRs touch the formation queue / stats sampler
- Sibling: perf/pathfinding (pathfinding fixes), feat/rts-debug (debug overlay)

Safe to merge first or in any order — out-of-order merges may produce small textual conflicts only in shared files.