### PR TITLE
perf: pathfinding stuck handling and group dispatch

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/unit/UnitActionItem.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitActionItem.java
@@ -403,15 +403,20 @@ public class UnitActionItem {
             List<Pair<LivingEntity, BlockPos>> formationPairs = UnitFormations.getMoveFormation(
                 level, new ArrayList<>(list), preselectedBlockPos
             );
+            // Filter out redundant moves once, then either dispatch immediately (small groups)
+            // or queue for time-sliced dispatch on the server (large groups) so we don't run
+            // N concurrent A* searches in the same tick.
+            List<Pair<LivingEntity, BlockPos>> filtered = new ArrayList<>(formationPairs.size());
             for (Pair<LivingEntity, BlockPos> pair : formationPairs) {
-                LivingEntity le = pair.getFirst();
-                BlockPos targetPos = pair.getSecond();
-
-                if (isRedundantMove((Unit) le, targetPos))
-                    continue;
-
-                Unit unit = (Unit) le;
-                unit.setMoveTarget(targetPos);
+                if (!isRedundantMove((Unit) pair.getFirst(), pair.getSecond()))
+                    filtered.add(pair);
+            }
+            if (level.isClientSide() || filtered.size() <= 20) {
+                for (Pair<LivingEntity, BlockPos> pair : filtered) {
+                    ((Unit) pair.getFirst()).setMoveTarget(pair.getSecond());
+                }
+            } else {
+                UnitServerEvents.queueFormationMove(filtered);
             }
         }
 

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
@@ -118,6 +118,26 @@ public class UnitServerEvents {
 
     private static final ArrayList<Pair<Integer, ChunkAccess>> forcedUnitChunks = new ArrayList<>();
 
+    // Time-sliced formation dispatch: large group MOVE commands are spread across multiple ticks
+    // to avoid the spike from N units all running A* in the same tick. LinkedHashMap preserves
+    // insertion order while letting a re-queued unit overwrite its old target (supersession).
+    private static final int FORMATION_DISPATCH_PER_TICK = 5;
+    private static final LinkedHashMap<Integer, Pair<LivingEntity, BlockPos>> formationDispatchQueue = new LinkedHashMap<>();
+
+    public static void queueFormationMove(List<Pair<LivingEntity, BlockPos>> pairs) {
+        synchronized (formationDispatchQueue) {
+            for (Pair<LivingEntity, BlockPos> p : pairs) {
+                formationDispatchQueue.put(p.getFirst().getId(), p);
+            }
+        }
+    }
+
+    public static int formationDispatchQueueSize() {
+        synchronized (formationDispatchQueue) {
+            return formationDispatchQueue.size();
+        }
+    }
+
     public static ArrayList<LivingEntity> getAllUnits() {
         return allUnits;
     }
@@ -640,6 +660,27 @@ public class UnitServerEvents {
         }
     }
 
+
+    @SubscribeEvent
+    public static void onFormationDispatchTick(TickEvent.LevelTickEvent evt) {
+        if (evt.phase != TickEvent.Phase.END || evt.level.isClientSide() || evt.level.dimension() != Level.OVERWORLD)
+            return;
+        synchronized (formationDispatchQueue) {
+            if (formationDispatchQueue.isEmpty())
+                return;
+            int processed = 0;
+            Iterator<Pair<LivingEntity, BlockPos>> it = formationDispatchQueue.values().iterator();
+            while (processed < FORMATION_DISPATCH_PER_TICK && it.hasNext()) {
+                Pair<LivingEntity, BlockPos> pair = it.next();
+                it.remove();
+                LivingEntity le = pair.getFirst();
+                if (le != null && le.isAlive() && le instanceof Unit unit) {
+                    unit.setMoveTarget(pair.getSecond());
+                }
+                processed += 1;
+            }
+        }
+    }
 
     // for some reason we have to use the level in the same tick as the unit actions or else level.getEntity returns
     // null

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/MeleeAttackBuildingGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/MeleeAttackBuildingGoal.java
@@ -33,7 +33,9 @@ public class MeleeAttackBuildingGoal extends MoveToTargetBlockGoal {
     protected BuildingPlacement buildingTarget;
 
     protected final int RECALC_COOLDOWN_MAX = 10;
-    protected int recalcCooldown = 0; // limit start() used by canContinueToUse
+    protected static final int MELEE_RECALC_COOLDOWN_CAP = 100; // 5s — attacks should respond faster than generic move
+    protected int currentMeleeRecalcCooldown = RECALC_COOLDOWN_MAX;
+    protected int recalcCooldown = 0; // limit start() used by tick()
 
     public MeleeAttackBuildingGoal(Mob mob) {
         super(mob, true, 0);
@@ -43,14 +45,23 @@ public class MeleeAttackBuildingGoal extends MoveToTargetBlockGoal {
         if (buildingTarget != null) {
 
             // for some reason, isDone() can sometimes be true even when moveTarget is nonnull and
-            // we haven't reached the target, esp. for Brutes
+            // we haven't reached the target, esp. for Brutes.
+            // A1+A5: if the repathed final node matches the previous one, the target is unreachable —
+            // stop instead of looping. Otherwise back off exponentially.
             if (this.mob.getNavigation().isDone() && moveTarget != null &&
                 this.mob.getOnPos().distSqr(moveTarget) > 1 && !isAttacking()) {
                 if (recalcCooldown > 0) {
                     recalcCooldown -= 1;
                 } else {
-                    recalcCooldown = RECALC_COOLDOWN_MAX;
+                    BlockPos oldFinalNode = getFinalNodePos();
                     this.start();
+                    BlockPos newFinalNode = getFinalNodePos();
+                    if (oldFinalNode != null && oldFinalNode.equals(newFinalNode)) {
+                        stopAttacking();
+                    } else {
+                        currentMeleeRecalcCooldown = Math.min(currentMeleeRecalcCooldown * 2, MELEE_RECALC_COOLDOWN_CAP);
+                    }
+                    recalcCooldown = currentMeleeRecalcCooldown;
                 }
             }
 
@@ -121,6 +132,7 @@ public class MeleeAttackBuildingGoal extends MoveToTargetBlockGoal {
 
     public void setBuildingTarget(BlockPos blockPos) {
         if (blockPos != null) {
+            currentMeleeRecalcCooldown = RECALC_COOLDOWN_MAX;
             if (this.mob.level().isClientSide()) {
                 BuildingPlacement b = BuildingUtils.findBuilding(this.mob.level().isClientSide(), blockPos);
                 if (b != null && b.isAttackable()) {

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
@@ -24,7 +24,14 @@ public class MoveToTargetBlockGoal extends Goal {
     @Nullable public BlockPos lastSelectedMoveTarget = null; // ignores unit formations, used for reducing move actions sent to server
 
     protected final int RECALC_COOLDOWN_MAX = 20;
-    protected void resetRecalcCooldown() { recalcCooldown = RECALC_COOLDOWN_MAX; }
+    protected static final int RECALC_COOLDOWN_CAP = 200; // ~10s cap for exponential backoff on stuck units
+    protected int currentRecalcCooldown = RECALC_COOLDOWN_MAX;
+    protected void resetRecalcCooldown() { recalcCooldown = currentRecalcCooldown; }
+    protected void backoffRecalcCooldown() {
+        currentRecalcCooldown = Math.min(currentRecalcCooldown * 2, RECALC_COOLDOWN_CAP);
+    }
+    protected void resetRecalcBackoff() { currentRecalcCooldown = RECALC_COOLDOWN_MAX; }
+    public boolean isInBackoff() { return currentRecalcCooldown > RECALC_COOLDOWN_MAX && moveTarget != null; }
     protected int recalcCooldown = 0; // limit start() used by canContinueToUse
 
     public MoveToTargetBlockGoal(Mob mob, boolean persistent, int reachRange) {
@@ -59,12 +66,14 @@ public class MoveToTargetBlockGoal extends Goal {
         // PathNavigation seems to have a max length so restart it if we haven't actually reached the target yet
         if (this.mob.getNavigation().isDone() && moveTarget != null &&
             this.mob.getOnPos().distSqr(moveTarget) > getMinDistToRecalculateSqr()) {
-            //BlockPos oldFinalNode = getFinalNodePos();
+            BlockPos oldFinalNode = getFinalNodePos();
             this.start();
-            //BlockPos newFinalNode = getFinalNodePos();
+            BlockPos newFinalNode = getFinalNodePos();
             // start() is very expensive, and it repeats every tick if the mob is stuck, eg. targeting over water
-            //if (oldFinalNode != null && oldFinalNode.equals(newFinalNode))
-            //    stopMoving();
+            if (oldFinalNode != null && oldFinalNode.equals(newFinalNode))
+                stopMoving();
+            else
+                backoffRecalcCooldown();
             resetRecalcCooldown();
             return true;
         }
@@ -81,28 +90,21 @@ public class MoveToTargetBlockGoal extends Goal {
 
     public void start() {
         if (moveTarget != null) {
-            AttributeInstance ai = mob.getAttribute(Attributes.FOLLOW_RANGE);
-            boolean improvedPathfinding = ai != null && ai.getBaseValue() == FOLLOW_RANGE_IMPROVED;
-            Path bestPath;
-            if (improvedPathfinding) {
-                ai.setBaseValue(FOLLOW_RANGE);
-                Path shortPath = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
-                BlockPos shortFinalPos = getFinalNodePos(shortPath);
-                ai.setBaseValue(FOLLOW_RANGE_IMPROVED);
-                Path longPath = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
-                BlockPos longFinalPos = getFinalNodePos(longPath);
-                bestPath = longPath;
-                if (shortFinalPos != null && longFinalPos != null) {
-                    BlockPos moveTargetXZ = new BlockPos(moveTarget.getX(), 0, moveTarget.getZ());
-                    double shortXZDist = new BlockPos(shortFinalPos.getX(), 0, shortFinalPos.getZ()).distSqr(moveTargetXZ);
-                    double longXZDist = new BlockPos(longFinalPos.getX(), 0, longFinalPos.getZ()).distSqr(moveTargetXZ);
-                    if (shortXZDist < longXZDist)
-                        bestPath = shortPath;
+            // Single createPath call. The improvedPathfinding (FOLLOW_RANGE_IMPROVED) attribute is left
+            // in place if present, so vanilla A* searches at the configured range. If the resulting path
+            // ends up suboptimal, the backoff in canContinueToUse handles retries / give-up.
+            Path path = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
+            if (path == null) {
+                AttributeInstance ai = mob.getAttribute(Attributes.FOLLOW_RANGE);
+                if (ai != null && ai.getBaseValue() == FOLLOW_RANGE_IMPROVED) {
+                    // Fallback: long-range search bailed (eg. hit maxVisitedNodes). Retry with the short
+                    // range — vanilla A* may give up sooner and return a useful partial path.
+                    ai.setBaseValue(FOLLOW_RANGE);
+                    path = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
+                    ai.setBaseValue(FOLLOW_RANGE_IMPROVED);
                 }
-            } else {
-                bestPath = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
             }
-            this.mob.getNavigation().moveTo(bestPath, Unit.getSpeedModifier((Unit) this.mob));
+            this.mob.getNavigation().moveTo(path, Unit.getSpeedModifier((Unit) this.mob));
         }
         else
             this.mob.getNavigation().stop();
@@ -113,6 +115,7 @@ public class MoveToTargetBlockGoal extends Goal {
             MiscUtil.addUnitCheckpoint((Unit) mob, bp, true);
         }
         this.moveTarget = bp;
+        resetRecalcBackoff();
 
         if (!this.mob.level().isClientSide())
             this.start();


### PR DESCRIPTION
Cuts wasted A* calls. Vanilla MC pathfinder isn't touched — all changes live in the Goal layer.

- `MoveToTargetBlockGoal.start()`: was running `createPath` twice (short + long) and picking the better. Now runs once, with a fallback only if the first returns null.
- `canContinueToUse`: re-enables the no-progress check that was commented out — if a repath lands at the same dead-end as last time, give up instead of looping forever.
- Exponential backoff for stuck units (cooldown doubles up to ~10s) so unreachable targets stop spamming retries.
- Group MOVE commands: when >20 units click the same target, spread `setMoveTarget` across ticks (5 per tick) instead of all in one. Kills the spike on big army commands.
- `MeleeAttackBuildingGoal` gets the same no-progress + backoff pattern (its cooldown was unbounded before).

### Files
`MoveToTargetBlockGoal.java`, `MeleeAttackBuildingGoal.java`, `UnitActionItem.java`, `UnitServerEvents.java`

### Sibling PRs
Shares `UnitServerEvents.java` with #419 (server-hotspots) but in a different section — no textual overlap. The debug overlay PR (`feat/rts-debug`) is stacked on top of this one and reads `MoveToTargetBlockGoal.isInBackoff()` introduced here.

Needs playtesting around water and walled-off targets.