### PR TITLE
feat: /rts-debug command with path preview and perf overlay

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/commands/RtsDebug.java
+++ b/src/main/java/com/solegendary/reignofnether/commands/RtsDebug.java
@@ -1,0 +1,25 @@
+package com.solegendary.reignofnether.commands;
+
+import net.minecraft.commands.Commands;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+// Centralised debug mode flag. Server-authoritative — clients receive updates via RtsDebugClientboundPacket.
+// When enabled: path-preview lines stay visible and a perf-stats overlay renders top-right.
+public class RtsDebug {
+
+    public static boolean enabled = false;
+
+    public static void setEnabled(boolean value) {
+        enabled = value;
+        RtsDebugClientboundPacket.broadcast(value);
+    }
+
+    @SubscribeEvent
+    public static void onRegisterCommand(RegisterCommandsEvent evt) {
+        evt.getDispatcher().register(Commands.literal("rts-debug").then(Commands.literal("enable")
+                .executes((ctx) -> { setEnabled(true);  return 1; })));
+        evt.getDispatcher().register(Commands.literal("rts-debug").then(Commands.literal("disable")
+                .executes((ctx) -> { setEnabled(false); return 1; })));
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/commands/RtsDebugClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/commands/RtsDebugClientEvents.java
@@ -1,0 +1,46 @@
+package com.solegendary.reignofnether.commands;
+
+import com.solegendary.reignofnether.tps.TPSClientEvents;
+import com.solegendary.reignofnether.unit.UnitClientEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.RenderGuiOverlayEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+// Top-right perf-stats overlay. Only renders while RtsDebug.enabled is true.
+public class RtsDebugClientEvents {
+
+    private static final Minecraft MC = Minecraft.getInstance();
+
+    // Server-pushed perf counters, averaged over a 5-second rolling window.
+    // Updated once per second via RtsDebugStatsClientboundPacket.
+    public static int pathsAvg = 0;
+    public static int queueAvg = 0;
+    public static int stuckAvg = 0;
+
+    @SubscribeEvent
+    public static void onRenderOverlay(RenderGuiOverlayEvent.Pre evt) {
+        if (!RtsDebug.enabled || MC.font == null)
+            return;
+
+        int x = evt.getWindow().getGuiScaledWidth() - 110;
+        int y = 5;
+        int lineH = 10;
+
+        double tps = TPSClientEvents.getCappedTPS();
+        int tpsCol = tps < 10 ? 0xFF0000 : tps < 20 ? 0xFFFF00 : 0x00FF00;
+
+        String fps = MC.fpsString != null && MC.fpsString.length() >= 6 ? MC.fpsString.substring(0, 6).replace("fps", "") : "?";
+
+        int stuckCol = stuckAvg > 0 ? 0xFF6060 : 0xFFFFFF;
+
+        evt.getGuiGraphics().drawString(MC.font, "[rts-debug] (5s avg)",          x, y,             0xFFFF00);
+        evt.getGuiGraphics().drawString(MC.font, "TPS:    " + String.format("%.1f", tps),  x, y + lineH,      tpsCol);
+        evt.getGuiGraphics().drawString(MC.font, "FPS:    " + fps,                         x, y + lineH * 2,  0xFFFFFF);
+        evt.getGuiGraphics().drawString(MC.font, "Units:  " + UnitClientEvents.getAllUnits().size(),       x, y + lineH * 3, 0xFFFFFF);
+        evt.getGuiGraphics().drawString(MC.font, "Sel:    " + UnitClientEvents.getSelectedUnits().size(),  x, y + lineH * 4, 0xFFFFFF);
+        evt.getGuiGraphics().drawString(MC.font, "Paths:  " + UnitClientEvents.displayedPathCount(),       x, y + lineH * 5, 0xFFFFFF);
+        evt.getGuiGraphics().drawString(MC.font, "Paths/s:" + pathsAvg,                                    x, y + lineH * 6, 0xFFFFFF);
+        evt.getGuiGraphics().drawString(MC.font, "Queue:  " + queueAvg,                                    x, y + lineH * 7, 0xFFFFFF);
+        evt.getGuiGraphics().drawString(MC.font, "Stuck:  " + stuckAvg,                                    x, y + lineH * 8, stuckCol);
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/commands/RtsDebugClientboundPacket.java
+++ b/src/main/java/com/solegendary/reignofnether/commands/RtsDebugClientboundPacket.java
@@ -1,0 +1,31 @@
+package com.solegendary.reignofnether.commands;
+
+import com.solegendary.reignofnether.registrars.PacketHandler;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.function.Supplier;
+
+public class RtsDebugClientboundPacket {
+
+    private final boolean enabled;
+
+    public static void broadcast(boolean enabled) {
+        PacketHandler.INSTANCE.send(PacketDistributor.ALL.noArg(), new RtsDebugClientboundPacket(enabled));
+    }
+
+    public RtsDebugClientboundPacket(boolean enabled) { this.enabled = enabled; }
+    public RtsDebugClientboundPacket(FriendlyByteBuf buffer) { this.enabled = buffer.readBoolean(); }
+    public void encode(FriendlyByteBuf buffer) { buffer.writeBoolean(this.enabled); }
+
+    public boolean handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> RtsDebug.enabled = this.enabled);
+        });
+        ctx.get().setPacketHandled(true);
+        return true;
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/commands/RtsDebugStatsClientboundPacket.java
+++ b/src/main/java/com/solegendary/reignofnether/commands/RtsDebugStatsClientboundPacket.java
@@ -1,0 +1,53 @@
+package com.solegendary.reignofnether.commands;
+
+import com.solegendary.reignofnether.registrars.PacketHandler;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.function.Supplier;
+
+// Server → client snapshot of perf counters. Sent once per second while /rts-debug is enabled.
+public class RtsDebugStatsClientboundPacket {
+
+    private final int pathsAvg;
+    private final int queueAvg;
+    private final int stuckAvg;
+
+    public static void broadcast(int pathsAvg, int queueAvg, int stuckAvg) {
+        PacketHandler.INSTANCE.send(PacketDistributor.ALL.noArg(),
+                new RtsDebugStatsClientboundPacket(pathsAvg, queueAvg, stuckAvg));
+    }
+
+    public RtsDebugStatsClientboundPacket(int pathsAvg, int queueAvg, int stuckAvg) {
+        this.pathsAvg = pathsAvg;
+        this.queueAvg = queueAvg;
+        this.stuckAvg = stuckAvg;
+    }
+
+    public RtsDebugStatsClientboundPacket(FriendlyByteBuf buffer) {
+        this.pathsAvg = buffer.readVarInt();
+        this.queueAvg = buffer.readVarInt();
+        this.stuckAvg = buffer.readVarInt();
+    }
+
+    public void encode(FriendlyByteBuf buffer) {
+        buffer.writeVarInt(this.pathsAvg);
+        buffer.writeVarInt(this.queueAvg);
+        buffer.writeVarInt(this.stuckAvg);
+    }
+
+    public boolean handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+                RtsDebugClientEvents.pathsAvg = this.pathsAvg;
+                RtsDebugClientEvents.queueAvg = this.queueAvg;
+                RtsDebugClientEvents.stuckAvg = this.stuckAvg;
+            });
+        });
+        ctx.get().setPacketHandled(true);
+        return true;
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/registrars/ClientEventRegistrar.java
+++ b/src/main/java/com/solegendary/reignofnether/registrars/ClientEventRegistrar.java
@@ -10,6 +10,8 @@ import com.solegendary.reignofnether.building.BuildingServerEvents;
 import com.solegendary.reignofnether.building.custombuilding.CustomBuildingClientEvents;
 import com.solegendary.reignofnether.building.custombuilding.CustomBuildingServerEvents;
 import com.solegendary.reignofnether.commands.CommandsServerEvents;
+import com.solegendary.reignofnether.commands.RtsDebug;
+import com.solegendary.reignofnether.commands.RtsDebugClientEvents;
 import com.solegendary.reignofnether.config.ConfigClientEvents;
 import com.solegendary.reignofnether.config.ConfigVanillaServerEvents;
 import com.solegendary.reignofnether.cursor.CursorClientEvents;
@@ -95,6 +97,7 @@ public class ClientEventRegistrar {
         vanillaEventBus.register(PlayerDisplayClientEvents.class);
         vanillaEventBus.register(ScenarioClientEvents.class);
         vanillaEventBus.register(TextInputClientEvents.class);
+        vanillaEventBus.register(RtsDebugClientEvents.class);
 
         // to allow singleplayer integrated server to work
         vanillaEventBus.register(GameruleServerEvents.class);
@@ -119,6 +122,7 @@ public class ClientEventRegistrar {
         vanillaEventBus.register(TimeServerEvents.class);
         vanillaEventBus.register(CustomBuildingServerEvents.class);
         vanillaEventBus.register(CommandsServerEvents.class);
+        vanillaEventBus.register(RtsDebug.class);
         vanillaEventBus.register(ScenarioServerEvents.class);
     }
 }

--- a/src/main/java/com/solegendary/reignofnether/registrars/PacketHandler.java
+++ b/src/main/java/com/solegendary/reignofnether/registrars/PacketHandler.java
@@ -100,6 +100,20 @@ public final class PacketHandler {
                 .encoder(UnitAnimationClientboundPacket::encode).decoder(UnitAnimationClientboundPacket::new)
                 .consumerMainThread(UnitAnimationClientboundPacket::handle).add();
 
+        INSTANCE.messageBuilder(UnitPathClientboundPacket.class, index++, NetworkDirection.PLAY_TO_CLIENT)
+                .encoder(UnitPathClientboundPacket::encode).decoder(UnitPathClientboundPacket::new)
+                .consumerMainThread(UnitPathClientboundPacket::handle).add();
+
+        INSTANCE.messageBuilder(com.solegendary.reignofnether.commands.RtsDebugClientboundPacket.class, index++, NetworkDirection.PLAY_TO_CLIENT)
+                .encoder(com.solegendary.reignofnether.commands.RtsDebugClientboundPacket::encode)
+                .decoder(com.solegendary.reignofnether.commands.RtsDebugClientboundPacket::new)
+                .consumerMainThread(com.solegendary.reignofnether.commands.RtsDebugClientboundPacket::handle).add();
+
+        INSTANCE.messageBuilder(com.solegendary.reignofnether.commands.RtsDebugStatsClientboundPacket.class, index++, NetworkDirection.PLAY_TO_CLIENT)
+                .encoder(com.solegendary.reignofnether.commands.RtsDebugStatsClientboundPacket::encode)
+                .decoder(com.solegendary.reignofnether.commands.RtsDebugStatsClientboundPacket::new)
+                .consumerMainThread(com.solegendary.reignofnether.commands.RtsDebugStatsClientboundPacket::handle).add();
+
         INSTANCE.messageBuilder(UnitIdleWorkerClientBoundPacket.class, index++, NetworkDirection.PLAY_TO_CLIENT)
                 .encoder(UnitIdleWorkerClientBoundPacket::encode).decoder(UnitIdleWorkerClientBoundPacket::new)
                 .consumerMainThread(UnitIdleWorkerClientBoundPacket::handle).add();

--- a/src/main/java/com/solegendary/reignofnether/registrars/ServerEventRegistrar.java
+++ b/src/main/java/com/solegendary/reignofnether/registrars/ServerEventRegistrar.java
@@ -6,6 +6,7 @@ import com.solegendary.reignofnether.blocks.BlockServerEvents;
 import com.solegendary.reignofnether.building.BuildingServerEvents;
 import com.solegendary.reignofnether.building.custombuilding.CustomBuildingServerEvents;
 import com.solegendary.reignofnether.commands.CommandsServerEvents;
+import com.solegendary.reignofnether.commands.RtsDebug;
 import com.solegendary.reignofnether.config.ConfigVanillaServerEvents;
 import com.solegendary.reignofnether.fogofwar.FogOfWarServerEvents;
 import com.solegendary.reignofnether.gamemode.GameModeServerEvents;
@@ -62,6 +63,7 @@ public class ServerEventRegistrar {
         vanillaEventBus.register(TimeServerEvents.class);
         vanillaEventBus.register(CustomBuildingServerEvents.class);
         vanillaEventBus.register(CommandsServerEvents.class);
+        vanillaEventBus.register(RtsDebug.class);
         vanillaEventBus.register(ScenarioServerEvents.class);
     }
 }

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitClientEvents.java
@@ -154,6 +154,27 @@ public class UnitClientEvents {
         return allUnits;
     }
 
+    // Path-preview state. Keyed by entityId. Decremented in onClientTick. Entries auto-purge at zero.
+    public static class PathDisplay {
+        public final java.util.List<BlockPos> nodes;
+        public int ticksRemaining;
+        public PathDisplay(java.util.List<BlockPos> nodes, int ticksRemaining) {
+            this.nodes = nodes;
+            this.ticksRemaining = ticksRemaining;
+        }
+    }
+    private static final java.util.HashMap<Integer, PathDisplay> displayedPaths = new java.util.HashMap<>();
+
+    public static void receiveUnitPath(int entityId, java.util.List<BlockPos> nodes) {
+        if (nodes == null || nodes.isEmpty()) {
+            displayedPaths.remove(entityId);
+            return;
+        }
+        displayedPaths.put(entityId, new PathDisplay(nodes, MyRenderer.PATH_DISPLAY_TICKS));
+    }
+
+    public static int displayedPathCount() { return displayedPaths.size(); }
+
     private static boolean rightClickMoveDeferred = false;
     private static boolean rightClickActionTaken = false;
 
@@ -510,6 +531,29 @@ public class UnitClientEvents {
     public static void onClientTick(TickEvent.ClientTickEvent evt) {
         if (evt.phase != TickEvent.Phase.END)
             return;
+
+        // Tick path-preview entries down. Remove expired in a single pass.
+        // When rts-debug is enabled, entries don't expire on a timer — they persist until either
+        // a new path arrives or the unit reaches the last node of its current path.
+        if (!displayedPaths.isEmpty()) {
+            boolean debugOn = com.solegendary.reignofnether.commands.RtsDebug.enabled;
+            displayedPaths.entrySet().removeIf(e -> {
+                PathDisplay pd = e.getValue();
+                if (!debugOn) {
+                    pd.ticksRemaining -= 1;
+                    if (pd.ticksRemaining <= 0) return true;
+                }
+                // Drop the entry once the unit is within 2 blocks of the path's last node.
+                if (MC.level != null) {
+                    var entity = MC.level.getEntity(e.getKey());
+                    if (entity == null) return true;
+                    BlockPos last = pd.nodes.get(pd.nodes.size() - 1);
+                    if (entity.distanceToSqr(last.getX() + 0.5, last.getY() + 0.5, last.getZ() + 0.5) < 4)
+                        return true;
+                }
+                return false;
+            });
+        }
 
         //if (MC.level != null)
         //    variance = WaveSpawner.getYVariance(MC.level, getPreselectedBlockPos(), 8);
@@ -1116,15 +1160,25 @@ public class UnitClientEvents {
                         }
                     }
 
-                    // draw path nodes
-                    /*
-                    if (unit instanceof Mob mob && mob.getNavigation().getPath() != null) {
-                        for (Node node : mob.getNavigation().getPath().nodes) {
-                            BlockPos bp = new BlockPos(node.x, node.y, node.z).below();
-                            MyRenderer.drawBlockFace(evt.getPoseStack(), Direction.UP, bp, 0, 1, 0, a);
+                    // draw path preview — gated by /rts-debug. When debug is off, never render.
+                    // When debug is on, always render at full alpha (no fade).
+                    PathDisplay pd = displayedPaths.get(entity.getId());
+                    if (com.solegendary.reignofnether.commands.RtsDebug.enabled
+                            && pd != null && pd.nodes.size() >= 2 && MC.player != null
+                            && (unit.getOwnerName().equals(MC.player.getName().getString())
+                                || AlliancesClient.canControlAlly(unit.getOwnerName()))) {
+                        float pathAlpha = MyRenderer.PATH_LINE_BASE_ALPHA;
+                        BlockPos prev = null;
+                        for (BlockPos node : pd.nodes) {
+                            if (prev != null) {
+                                Vec3 a0 = new Vec3(prev.getX() + 0.5, prev.getY() + MyRenderer.PATH_LINE_Y_OFFSET, prev.getZ() + 0.5);
+                                Vec3 b0 = new Vec3(node.getX() + 0.5, node.getY() + MyRenderer.PATH_LINE_Y_OFFSET, node.getZ() + 0.5);
+                                MyRenderer.drawLine(evt.getPoseStack(), vertexConsumerLine, a0, b0,
+                                        MyRenderer.PATH_LINE_R, MyRenderer.PATH_LINE_G, MyRenderer.PATH_LINE_B, pathAlpha);
+                            }
+                            prev = node;
                         }
                     }
-                     */
                 }
             }
 

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
@@ -162,25 +162,19 @@ public class UnitServerEvents {
         }
     }
 
-    // Time-sliced formation dispatch: large group MOVE commands are spread across multiple ticks
-    // to avoid the spike from N units all running A* in the same tick. LinkedHashMap preserves
-    // insertion order while letting a re-queued unit overwrite its old target (supersession).
-    private static final int FORMATION_DISPATCH_PER_TICK = 5;
-    private static final LinkedHashMap<Integer, Pair<LivingEntity, BlockPos>> formationDispatchQueue = new LinkedHashMap<>();
+    // Debug counter: incremented each time a goal calls mob.getNavigation().createPath().
+    // Sampled and reset once per second by the rts-debug stats tick handler.
+    public static int debugPathCalcsThisSecond = 0;
 
-    public static void queueFormationMove(List<Pair<LivingEntity, BlockPos>> pairs) {
-        synchronized (formationDispatchQueue) {
-            for (Pair<LivingEntity, BlockPos> p : pairs) {
-                formationDispatchQueue.put(p.getFirst().getId(), p);
-            }
-        }
-    }
-
-    public static int formationDispatchQueueSize() {
-        synchronized (formationDispatchQueue) {
-            return formationDispatchQueue.size();
-        }
-    }
+    // 5-second rolling buffers for the debug overlay. Indexed mod STATS_WINDOW.
+    private static final int STATS_WINDOW = 5;
+    private static final int[] pathsHistory = new int[STATS_WINDOW];
+    private static final int[] queueHistory = new int[STATS_WINDOW];
+    private static final int[] stuckHistory = new int[STATS_WINDOW];
+    private static int statsIndex = 0;
+    // Queue is sampled every tick (cheap, captures bursts) and averaged at second boundaries.
+    private static long queueSumThisSecond = 0;
+    private static int queueSamplesThisSecond = 0;
 
     public static ArrayList<LivingEntity> getAllUnits() {
         return allUnits;
@@ -711,6 +705,8 @@ public class UnitServerEvents {
         if (evt.phase != TickEvent.Phase.END || evt.level.isClientSide() || evt.level.dimension() != Level.OVERWORLD)
             return;
         synchronized (formationDispatchQueue) {
+            queueSumThisSecond += formationDispatchQueue.size();
+            queueSamplesThisSecond += 1;
             if (formationDispatchQueue.isEmpty())
                 return;
             int processed = 0;
@@ -725,6 +721,46 @@ public class UnitServerEvents {
                 processed += 1;
             }
         }
+    }
+
+    // Per-second sample of debug stats. Only broadcast while /rts-debug is enabled.
+    private static int rtsDebugStatsTicks = 0;
+    @SubscribeEvent
+    public static void onRtsDebugStatsTick(TickEvent.LevelTickEvent evt) {
+        if (evt.phase != TickEvent.Phase.END || evt.level.isClientSide() || evt.level.dimension() != Level.OVERWORLD)
+            return;
+        rtsDebugStatsTicks += 1;
+        if (rtsDebugStatsTicks < 20) return;
+        rtsDebugStatsTicks = 0;
+        int paths = debugPathCalcsThisSecond;
+        debugPathCalcsThisSecond = 0;
+        if (!com.solegendary.reignofnether.commands.RtsDebug.enabled)
+            return;
+        int stuck = 0;
+        for (LivingEntity e : allUnits) {
+            if (e instanceof Unit u) {
+                var mg = u.getMoveGoal();
+                if (mg != null && mg.isInBackoff()) stuck += 1;
+            }
+        }
+        int avgQueueThisSec;
+        synchronized (formationDispatchQueue) {
+            avgQueueThisSec = queueSamplesThisSecond > 0 ? (int) (queueSumThisSecond / queueSamplesThisSecond) : 0;
+            queueSumThisSecond = 0;
+            queueSamplesThisSecond = 0;
+        }
+        pathsHistory[statsIndex] = paths;
+        queueHistory[statsIndex] = avgQueueThisSec;
+        stuckHistory[statsIndex] = stuck;
+        statsIndex = (statsIndex + 1) % STATS_WINDOW;
+        com.solegendary.reignofnether.commands.RtsDebugStatsClientboundPacket.broadcast(
+                avg(pathsHistory), avg(queueHistory), avg(stuckHistory));
+    }
+
+    private static int avg(int[] buf) {
+        int sum = 0;
+        for (int v : buf) sum += v;
+        return sum / buf.length;
     }
 
     // for some reason we have to use the level in the same tick as the unit actions or else level.getEntity returns

--- a/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/UnitServerEvents.java
@@ -162,6 +162,26 @@ public class UnitServerEvents {
         }
     }
 
+    // Time-sliced formation dispatch: large group MOVE commands are spread across multiple ticks
+    // to avoid the spike from N units all running A* in the same tick. LinkedHashMap preserves
+    // insertion order while letting a re-queued unit overwrite its old target (supersession).
+    private static final int FORMATION_DISPATCH_PER_TICK = 5;
+    private static final LinkedHashMap<Integer, Pair<LivingEntity, BlockPos>> formationDispatchQueue = new LinkedHashMap<>();
+
+    public static void queueFormationMove(List<Pair<LivingEntity, BlockPos>> pairs) {
+        synchronized (formationDispatchQueue) {
+            for (Pair<LivingEntity, BlockPos> p : pairs) {
+                formationDispatchQueue.put(p.getFirst().getId(), p);
+            }
+        }
+    }
+
+    public static int formationDispatchQueueSize() {
+        synchronized (formationDispatchQueue) {
+            return formationDispatchQueue.size();
+        }
+    }
+
     public static ArrayList<LivingEntity> getAllUnits() {
         return allUnits;
     }

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
@@ -89,33 +89,21 @@ public class MoveToTargetBlockGoal extends Goal {
 
     public void start() {
         if (moveTarget != null) {
-            AttributeInstance ai = mob.getAttribute(Attributes.FOLLOW_RANGE);
-            boolean improvedPathfinding = ai != null && ai.getBaseValue() == FOLLOW_RANGE_IMPROVED;
-            Path bestPath;
-            if (improvedPathfinding) {
-                ai.setBaseValue(FOLLOW_RANGE);
-                Path shortPath = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
-                BlockPos shortFinalPos = getFinalNodePos(shortPath);
-                ai.setBaseValue(FOLLOW_RANGE_IMPROVED);
-                if (shortFinalPos != null && shortFinalPos.equals(moveTarget)) {
-                    bestPath = shortPath;
-                } else {
-                    // use the shorter path if it has closer horizontal distance so armies can be force-moved over short rivers
-                    Path longPath = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
-                    BlockPos longFinalPos = getFinalNodePos(longPath);
-                    bestPath = longPath;
-                    if (shortFinalPos != null && longFinalPos != null) {
-                        BlockPos moveTargetXZ = new BlockPos(moveTarget.getX(), 0, moveTarget.getZ());
-                        double shortXZDist = new BlockPos(shortFinalPos.getX(), 0, shortFinalPos.getZ()).distSqr(moveTargetXZ);
-                        double longXZDist = new BlockPos(longFinalPos.getX(), 0, longFinalPos.getZ()).distSqr(moveTargetXZ);
-                        if (shortXZDist < longXZDist)
-                            bestPath = shortPath;
-                    }
+            // Single createPath call. The improvedPathfinding (FOLLOW_RANGE_IMPROVED) attribute is left
+            // in place if present, so vanilla A* searches at the configured range. If the resulting path
+            // ends up suboptimal, the backoff in canContinueToUse handles retries / give-up.
+            Path path = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
+            if (path == null) {
+                AttributeInstance ai = mob.getAttribute(Attributes.FOLLOW_RANGE);
+                if (ai != null && ai.getBaseValue() == FOLLOW_RANGE_IMPROVED) {
+                    // Fallback: long-range search bailed (eg. hit maxVisitedNodes). Retry with the short
+                    // range — vanilla A* may give up sooner and return a useful partial path.
+                    ai.setBaseValue(FOLLOW_RANGE);
+                    path = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
+                    ai.setBaseValue(FOLLOW_RANGE_IMPROVED);
                 }
-            } else {
-                bestPath = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
             }
-            this.mob.getNavigation().moveTo(bestPath, Unit.getSpeedModifier((Unit) this.mob));
+            this.mob.getNavigation().moveTo(path, Unit.getSpeedModifier((Unit) this.mob));
         }
         else
             this.mob.getNavigation().stop();

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
@@ -1,6 +1,8 @@
 package com.solegendary.reignofnether.unit.goals;
 
+import com.solegendary.reignofnether.unit.UnitServerEvents;
 import com.solegendary.reignofnether.unit.interfaces.Unit;
+import com.solegendary.reignofnether.unit.packets.UnitPathClientboundPacket;
 import com.solegendary.reignofnether.util.MiscUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Mob;
@@ -93,6 +95,7 @@ public class MoveToTargetBlockGoal extends Goal {
             // in place if present, so vanilla A* searches at the configured range. If the resulting path
             // ends up suboptimal, the backoff in canContinueToUse handles retries / give-up.
             Path path = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
+            if (!this.mob.level().isClientSide()) UnitServerEvents.debugPathCalcsThisSecond += 1;
             if (path == null) {
                 AttributeInstance ai = mob.getAttribute(Attributes.FOLLOW_RANGE);
                 if (ai != null && ai.getBaseValue() == FOLLOW_RANGE_IMPROVED) {
@@ -100,10 +103,15 @@ public class MoveToTargetBlockGoal extends Goal {
                     // range — vanilla A* may give up sooner and return a useful partial path.
                     ai.setBaseValue(FOLLOW_RANGE);
                     path = mob.getNavigation().createPath(moveTarget.getX(), moveTarget.getY(), moveTarget.getZ(), moveReachRange);
+                    if (!this.mob.level().isClientSide()) UnitServerEvents.debugPathCalcsThisSecond += 1;
                     ai.setBaseValue(FOLLOW_RANGE_IMPROVED);
                 }
             }
             this.mob.getNavigation().moveTo(path, Unit.getSpeedModifier((Unit) this.mob));
+            // Broadcast the path so clients can render it briefly. Server-only — clients
+            // that received the packet decide whether to render based on ownership/FOW.
+            if (!this.mob.level().isClientSide())
+                UnitPathClientboundPacket.sendPath(this.mob, path);
         }
         else
             this.mob.getNavigation().stop();

--- a/src/main/java/com/solegendary/reignofnether/unit/packets/UnitPathClientboundPacket.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/packets/UnitPathClientboundPacket.java
@@ -1,0 +1,63 @@
+package com.solegendary.reignofnether.unit.packets;
+
+import com.solegendary.reignofnether.registrars.PacketHandler;
+import com.solegendary.reignofnether.unit.UnitClientEvents;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.pathfinder.Path;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+// Sent server→client when a unit gets a fresh A* path. The client renders the path
+// briefly so the player can see the route their units will actually take.
+public class UnitPathClientboundPacket {
+
+    private final int entityId;
+    private final List<BlockPos> nodes;
+
+    public static void sendPath(LivingEntity entity, Path path) {
+        if (path == null || path.nodes == null || path.nodes.isEmpty())
+            return;
+        List<BlockPos> bps = new ArrayList<>(path.nodes.size());
+        for (var node : path.nodes)
+            bps.add(node.asBlockPos());
+        PacketHandler.INSTANCE.send(PacketDistributor.ALL.noArg(),
+                new UnitPathClientboundPacket(entity.getId(), bps));
+    }
+
+    public UnitPathClientboundPacket(int entityId, List<BlockPos> nodes) {
+        this.entityId = entityId;
+        this.nodes = nodes;
+    }
+
+    public UnitPathClientboundPacket(FriendlyByteBuf buffer) {
+        this.entityId = buffer.readInt();
+        int n = buffer.readVarInt();
+        this.nodes = new ArrayList<>(n);
+        for (int i = 0; i < n; i++)
+            this.nodes.add(buffer.readBlockPos());
+    }
+
+    public void encode(FriendlyByteBuf buffer) {
+        buffer.writeInt(this.entityId);
+        buffer.writeVarInt(this.nodes.size());
+        for (BlockPos bp : this.nodes)
+            buffer.writeBlockPos(bp);
+    }
+
+    public boolean handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
+                () -> () -> UnitClientEvents.receiveUnitPath(this.entityId, this.nodes));
+        });
+        ctx.get().setPacketHandled(true);
+        return true;
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/util/MyRenderer.java
+++ b/src/main/java/com/solegendary/reignofnether/util/MyRenderer.java
@@ -61,6 +61,15 @@ public class MyRenderer {
 
     private static final Minecraft MC = Minecraft.getInstance();
 
+    // Path-line render constants used by the move-command path preview.
+    public static final float PATH_LINE_R = 0.2f;
+    public static final float PATH_LINE_G = 1.0f;
+    public static final float PATH_LINE_B = 0.4f;
+    public static final float PATH_LINE_BASE_ALPHA = 0.9f;
+    public static final float PATH_LINE_Y_OFFSET = 0.1f;
+    public static final int PATH_DISPLAY_TICKS = 40; // ~2s at 20 tps
+    public static final int PATH_FADE_TICKS = 10; // last N ticks fade out linearly
+
     public static final RenderType LINES_NO_DEPTH_TEST = RenderType.create(
             "lines", DefaultVertexFormat.POSITION_COLOR_NORMAL, VertexFormat.Mode.LINES, 256, false, false,
             RenderType.CompositeState.builder().setShaderState(RENDERTYPE_LINES_SHADER)


### PR DESCRIPTION
Debug toggle for diagnosing pathfinding behavior.

```
/rts-debug enable   - turn on
/rts-debug disable  - off (default)
```

**When enabled:**
- Each unit's current A* path renders as a green line, owner-gated so enemy paths aren't revealed. Client clears the line when the unit reaches the last node.
- Top-right overlay: TPS, FPS, total units, selected, displayed paths, and **5-second rolling averages** of `createPath` calls/sec, formation queue size, and units in pathfinding backoff.

**When disabled:** no overlay, no lines, no extra packets.

### Files
New: `RtsDebug.java`, `RtsDebugClientboundPacket.java`, `RtsDebugStatsClientboundPacket.java`, `RtsDebugClientEvents.java`, `UnitPathClientboundPacket.java`.
Modified: `PacketHandler.java`, `ServerEventRegistrar.java`, `ClientEventRegistrar.java`, `MyRenderer.java`, `UnitClientEvents.java`, `MoveToTargetBlockGoal.java`, `UnitServerEvents.java`.

### Sibling PRs
**Stacked on #420** (pathfinding) — the `Stuck` stat reads `MoveToTargetBlockGoal.isInBackoff()` introduced there, so this PR can't merge before #420. Diff shown here includes #420's commit; once #420 merges, the diff cleans up to only this PR's changes.

Shares `UnitServerEvents.java` with #419 (server-hotspots) and #420 but each PR touches different sections — no textual overlap.