### PR TITLE
Optional square minimap

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/config/ReignOfNetherClientConfigs.java
+++ b/src/main/java/com/solegendary/reignofnether/config/ReignOfNetherClientConfigs.java
@@ -16,6 +16,7 @@ public class ReignOfNetherClientConfigs {
 
     public static final ForgeConfigSpec.ConfigValue<Boolean> USE_PLAYER_COLORS;
     public static final ForgeConfigSpec.ConfigValue<Integer> CAMERA_SENSITIVITY;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> SQUARE_MINIMAP;
 
     static {
         BUILDER.push("Configuration File");
@@ -30,6 +31,7 @@ public class ReignOfNetherClientConfigs {
         PLAYER_COLOR_ENEMY = BUILDER.define("player_color_enemy", PlayerColors.COLOR_HOSTILE.id);
         USE_PLAYER_COLORS = BUILDER.define("use_player_colors", false);
         CAMERA_SENSITIVITY = BUILDER.define("camera_sensitivity", 10);
+        SQUARE_MINIMAP = BUILDER.define("square_minimap", false);
         SPEC = BUILDER.build();
     }
 

--- a/src/main/java/com/solegendary/reignofnether/config/ReignOfNetherConfigScreen.java
+++ b/src/main/java/com/solegendary/reignofnether/config/ReignOfNetherConfigScreen.java
@@ -35,6 +35,7 @@ public class ReignOfNetherConfigScreen extends Screen {
     protected void init() {
         super.init();
         this.buildColorSettings(50);
+        this.buildMinimapSettings(150);
         this.addRenderableWidget(button(this.width / 2 - 75, this.height - 29, 150, 20, CommonComponents.GUI_BACK, button -> this.minecraft.setScreen(this.parent)));
     }
 
@@ -77,5 +78,16 @@ public class ReignOfNetherConfigScreen extends Screen {
         addRenderableWidget(new ConfigCheckbox(ReignOfNetherClientConfigs.USE_PLAYER_COLORS, "Using player colors", "Using alliance colors")
                 .pos(colorRect.left(), colorRect.bottom())
                 .size(colorRect.width(), labelHeight));
+    }
+
+    private void buildMinimapSettings(int y) {
+        int width = 200;
+        int labelHeight = 20;
+        int left = this.width / 2 - width / 2;
+
+        addRenderableOnly(new Label("Minimap").pos(left, y).size(width, labelHeight));
+        addRenderableWidget(new ConfigCheckbox(ReignOfNetherClientConfigs.SQUARE_MINIMAP, "Square minimap", "Diamond minimap")
+                .pos(left, y + labelHeight)
+                .size(width, labelHeight));
     }
 }

--- a/src/main/java/com/solegendary/reignofnether/hud/HudClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/hud/HudClientEvents.java
@@ -16,6 +16,7 @@ import com.solegendary.reignofnether.building.custombuilding.CustomBuilding;
 import com.solegendary.reignofnether.building.custombuilding.CustomBuildingClientEvents;
 import com.solegendary.reignofnether.building.production.ActiveProduction;
 import com.solegendary.reignofnether.config.ConfigClientEvents;
+import com.solegendary.reignofnether.config.ReignOfNetherClientConfigs;
 import com.solegendary.reignofnether.cursor.CursorClientEvents;
 import com.solegendary.reignofnether.gamemode.ClientGameModeHelper;
 import com.solegendary.reignofnether.gamemode.GameMode;
@@ -1334,126 +1335,181 @@ public class HudClientEvents {
             }
         }
 
-        // ---------------------
-        // Attack warning button
-        // ---------------------
+        // -------------------------
+        // Minimap buttons + warning
+        // -------------------------
+        boolean squareMinimap = ReignOfNetherClientConfigs.SQUARE_MINIMAP.get();
+
         Button attackWarningButton = AttackWarningClientEvents.getWarningButton();
-        if (!attackWarningButton.isHidden.get()) {
-            attackWarningButton.render(evt.getGuiGraphics(),
-                screenWidth - (MinimapClientEvents.getMapGuiRadius() * 2) - (MinimapClientEvents.CORNER_OFFSET * 2)
-                    - 14,
-                screenHeight - MinimapClientEvents.getMapGuiRadius() - (MinimapClientEvents.CORNER_OFFSET * 2) - 2,
-                mouseX,
-                mouseY
-            );
-            renderedButtons.add(attackWarningButton);
-        }
-
-        // ----------------------
-        // Map size toggle button
-        // ----------------------
         Button toggleMapSizeButton = MinimapClientEvents.getToggleSizeButton();
-        if (!toggleMapSizeButton.isHidden.get()) {
-            toggleMapSizeButton.render(evt.getGuiGraphics(),
-                    screenWidth - (toggleMapSizeButton.iconSize * 2),
-                    screenHeight - (toggleMapSizeButton.iconSize * 2),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(toggleMapSizeButton);
-        }
-
         Button markerModeButton = MinimapClientEvents.getMarkerModeButton();
-        if (!markerModeButton.isHidden.get()) {
-            markerModeButton.render(evt.getGuiGraphics(),
-                screenWidth - (markerModeButton.iconSize * (MinimapClientEvents.isLargeMap() ? 12 : 8)),
-                screenHeight - (markerModeButton.iconSize * 2),
-                mouseX, mouseY
-            );
-            renderedButtons.add(markerModeButton);
-        }
-
         Button camSensitivityButton = MinimapClientEvents.getCamSensitivityButton();
-        if (!camSensitivityButton.isHidden.get()) {
-            camSensitivityButton.render(evt.getGuiGraphics(),
-                    screenWidth - (camSensitivityButton.iconSize * 4),
-                    screenHeight - (camSensitivityButton.iconSize * 2),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(camSensitivityButton);
-        }
         Button mapLockButton = MinimapClientEvents.getMapLockButton();
-        if (!mapLockButton.isHidden.get()) {
-            mapLockButton.render(evt.getGuiGraphics(),
-                    screenWidth - (mapLockButton.iconSize * 2),
-                    screenHeight - (mapLockButton.iconSize * 4),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(mapLockButton);
-        }
         Button highlightAnimalsButton = MinimapClientEvents.getHighlightAnimalsButton();
-        if (!highlightAnimalsButton.isHidden.get()) {
-            highlightAnimalsButton.render(evt.getGuiGraphics(),
-                    screenWidth - (highlightAnimalsButton.iconSize * 2),
-                    screenHeight - (highlightAnimalsButton.iconSize * 6),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(highlightAnimalsButton);
-        }
         Button nightCirclesButton = MinimapClientEvents.getNightCirclesModeButton();
-        if (!nightCirclesButton.isHidden.get()) {
-            nightCirclesButton.render(evt.getGuiGraphics(),
-                    screenWidth - (nightCirclesButton.iconSize * 4),
-                    screenHeight - (nightCirclesButton.iconSize * 4),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(nightCirclesButton);
-        }
         Button leavesHidingButton = OrthoviewClientEvents.getLeavesHidingButton();
-        if (!leavesHidingButton.isHidden.get()) {
-            leavesHidingButton.render(evt.getGuiGraphics(),
-                    screenWidth - (leavesHidingButton.iconSize * 6),
-                    screenHeight - (leavesHidingButton.iconSize * 2),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(leavesHidingButton);
-        }
         Button toggleTeamColorsButton = PlayerColors.getToggleTeamColorsButton();
-        if (!toggleTeamColorsButton.isHidden.get()) {
-            toggleTeamColorsButton.render(evt.getGuiGraphics(),
-                    screenWidth - (toggleTeamColorsButton.iconSize * 6),
-                    screenHeight - (toggleTeamColorsButton.iconSize * 4),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(toggleTeamColorsButton);
-        }
-
         Button rotateCW = MinimapClientEvents.getCameraRotateCWButton();
-        if (!rotateCW.isHidden.get()) {
-            rotateCW.render(evt.getGuiGraphics(),
-                    screenWidth - (rotateCW.iconSize * (MinimapClientEvents.isLargeMap() ? 8 : 4)),
-                    screenHeight - (rotateCW.iconSize * 2),
-                    mouseX,
-                    mouseY
-            );
-            renderedButtons.add(rotateCW);
-        }
-
         Button rotateCCW = MinimapClientEvents.getCameraRotateCCWButton();
-        if (!rotateCCW.isHidden.get()) {
-            rotateCCW.render(evt.getGuiGraphics(),
-                    screenWidth - (rotateCCW.iconSize * (MinimapClientEvents.isLargeMap() ? 10 : 6)),
-                    screenHeight - (rotateCCW.iconSize * 2),
+
+        if (squareMinimap) {
+            int radius = MinimapClientEvents.getMapGuiRadius();
+            int co = MinimapClientEvents.CORNER_OFFSET;
+            float baseHalf = (float) (radius / Math.sqrt(2));
+            float half = baseHalf * MinimapClientEvents.SQUARE_SCALE;
+            // bottom-right corner of the minimap is fixed at the screen's bottom-right (with co padding)
+            float brX = screenWidth - co;
+            float brY = screenHeight - co;
+            int mmLeft = (int) (brX - 2 * half);
+            int mmBottom = (int) brY;
+
+            int frameSize = toggleMapSizeButton.iconFrameSize; // 22 — actual rendered frame
+            int stride = toggleMapSizeButton.iconSize * 2;     // 28, matches original spacing
+            int gridRight = mmLeft - 12;                       // shifted further left
+            int gridBottom = mmBottom + 4;                     // shifted a touch lower than the map bottom
+
+            int r0y = gridBottom - frameSize;            // bottom row: frame bottom = map bottom
+            int r1y = r0y - stride;                       // top row
+            int c0x = gridRight - frameSize;             // rightmost column: frame right = map left - 4
+            int c1x = c0x - stride;
+            int c2x = c1x - stride;
+            int c3x = c2x - stride;
+            int c4x = c3x - stride;
+
+            // bottom row: map controls (most-used)
+            if (!toggleMapSizeButton.isHidden.get()) {
+                toggleMapSizeButton.render(evt.getGuiGraphics(), c0x, r0y, mouseX, mouseY);
+                renderedButtons.add(toggleMapSizeButton);
+            }
+            if (!markerModeButton.isHidden.get()) {
+                markerModeButton.render(evt.getGuiGraphics(), c1x, r0y, mouseX, mouseY);
+                renderedButtons.add(markerModeButton);
+            }
+            if (!mapLockButton.isHidden.get()) {
+                mapLockButton.render(evt.getGuiGraphics(), c2x, r0y, mouseX, mouseY);
+                renderedButtons.add(mapLockButton);
+            }
+            if (!rotateCCW.isHidden.get()) {
+                rotateCCW.render(evt.getGuiGraphics(), c3x, r0y, mouseX, mouseY);
+                renderedButtons.add(rotateCCW);
+            }
+            if (!rotateCW.isHidden.get()) {
+                rotateCW.render(evt.getGuiGraphics(), c4x, r0y, mouseX, mouseY);
+                renderedButtons.add(rotateCW);
+            }
+
+            // top row: view toggles
+            if (!camSensitivityButton.isHidden.get()) {
+                camSensitivityButton.render(evt.getGuiGraphics(), c0x, r1y, mouseX, mouseY);
+                renderedButtons.add(camSensitivityButton);
+            }
+            if (!nightCirclesButton.isHidden.get()) {
+                nightCirclesButton.render(evt.getGuiGraphics(), c1x, r1y, mouseX, mouseY);
+                renderedButtons.add(nightCirclesButton);
+            }
+            if (!highlightAnimalsButton.isHidden.get()) {
+                highlightAnimalsButton.render(evt.getGuiGraphics(), c2x, r1y, mouseX, mouseY);
+                renderedButtons.add(highlightAnimalsButton);
+            }
+            if (!leavesHidingButton.isHidden.get()) {
+                leavesHidingButton.render(evt.getGuiGraphics(), c3x, r1y, mouseX, mouseY);
+                renderedButtons.add(leavesHidingButton);
+            }
+            if (!toggleTeamColorsButton.isHidden.get()) {
+                toggleTeamColorsButton.render(evt.getGuiGraphics(), c4x, r1y, mouseX, mouseY);
+                renderedButtons.add(toggleTeamColorsButton);
+            }
+
+            // attack warning: above the grid, aligned right
+            if (!attackWarningButton.isHidden.get()) {
+                attackWarningButton.render(evt.getGuiGraphics(), c0x, r1y - stride - 4, mouseX, mouseY);
+                renderedButtons.add(attackWarningButton);
+            }
+        } else {
+            // ---------------------
+            // Attack warning button (diamond layout)
+            // ---------------------
+            if (!attackWarningButton.isHidden.get()) {
+                attackWarningButton.render(evt.getGuiGraphics(),
+                    screenWidth - (MinimapClientEvents.getMapGuiRadius() * 2) - (MinimapClientEvents.CORNER_OFFSET * 2)
+                        - 14,
+                    screenHeight - MinimapClientEvents.getMapGuiRadius() - (MinimapClientEvents.CORNER_OFFSET * 2) - 2,
                     mouseX,
                     mouseY
-            );
-            renderedButtons.add(rotateCCW);
+                );
+                renderedButtons.add(attackWarningButton);
+            }
+
+            if (!toggleMapSizeButton.isHidden.get()) {
+                toggleMapSizeButton.render(evt.getGuiGraphics(),
+                        screenWidth - (toggleMapSizeButton.iconSize * 2),
+                        screenHeight - (toggleMapSizeButton.iconSize * 2),
+                        mouseX, mouseY);
+                renderedButtons.add(toggleMapSizeButton);
+            }
+            if (!markerModeButton.isHidden.get()) {
+                markerModeButton.render(evt.getGuiGraphics(),
+                    screenWidth - (markerModeButton.iconSize * (MinimapClientEvents.isLargeMap() ? 12 : 8)),
+                    screenHeight - (markerModeButton.iconSize * 2),
+                    mouseX, mouseY);
+                renderedButtons.add(markerModeButton);
+            }
+            if (!camSensitivityButton.isHidden.get()) {
+                camSensitivityButton.render(evt.getGuiGraphics(),
+                        screenWidth - (camSensitivityButton.iconSize * 4),
+                        screenHeight - (camSensitivityButton.iconSize * 2),
+                        mouseX, mouseY);
+                renderedButtons.add(camSensitivityButton);
+            }
+            if (!mapLockButton.isHidden.get()) {
+                mapLockButton.render(evt.getGuiGraphics(),
+                        screenWidth - (mapLockButton.iconSize * 2),
+                        screenHeight - (mapLockButton.iconSize * 4),
+                        mouseX, mouseY);
+                renderedButtons.add(mapLockButton);
+            }
+            if (!highlightAnimalsButton.isHidden.get()) {
+                highlightAnimalsButton.render(evt.getGuiGraphics(),
+                        screenWidth - (highlightAnimalsButton.iconSize * 2),
+                        screenHeight - (highlightAnimalsButton.iconSize * 6),
+                        mouseX, mouseY);
+                renderedButtons.add(highlightAnimalsButton);
+            }
+            if (!nightCirclesButton.isHidden.get()) {
+                nightCirclesButton.render(evt.getGuiGraphics(),
+                        screenWidth - (nightCirclesButton.iconSize * 4),
+                        screenHeight - (nightCirclesButton.iconSize * 4),
+                        mouseX, mouseY);
+                renderedButtons.add(nightCirclesButton);
+            }
+            if (!leavesHidingButton.isHidden.get()) {
+                leavesHidingButton.render(evt.getGuiGraphics(),
+                        screenWidth - (leavesHidingButton.iconSize * 6),
+                        screenHeight - (leavesHidingButton.iconSize * 2),
+                        mouseX, mouseY);
+                renderedButtons.add(leavesHidingButton);
+            }
+            if (!toggleTeamColorsButton.isHidden.get()) {
+                toggleTeamColorsButton.render(evt.getGuiGraphics(),
+                        screenWidth - (toggleTeamColorsButton.iconSize * 6),
+                        screenHeight - (toggleTeamColorsButton.iconSize * 4),
+                        mouseX, mouseY);
+                renderedButtons.add(toggleTeamColorsButton);
+            }
+            if (!rotateCW.isHidden.get()) {
+                rotateCW.render(evt.getGuiGraphics(),
+                        screenWidth - (rotateCW.iconSize * (MinimapClientEvents.isLargeMap() ? 8 : 4)),
+                        screenHeight - (rotateCW.iconSize * 2),
+                        mouseX, mouseY);
+                renderedButtons.add(rotateCW);
+            }
+            if (!rotateCCW.isHidden.get()) {
+                rotateCCW.render(evt.getGuiGraphics(),
+                        screenWidth - (rotateCCW.iconSize * (MinimapClientEvents.isLargeMap() ? 10 : 6)),
+                        screenHeight - (rotateCCW.iconSize * 2),
+                        mouseX, mouseY);
+                renderedButtons.add(rotateCCW);
+            }
         }
 
         // ------------------------------

--- a/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/minimap/MinimapClientEvents.java
@@ -12,6 +12,7 @@ import com.solegendary.reignofnether.building.BuildingClientEvents;
 import com.solegendary.reignofnether.building.BuildingPlacement;
 import com.solegendary.reignofnether.building.addon.RangeIndicatorAddon;
 import com.solegendary.reignofnether.building.buildings.shared.AbstractBridge;
+import com.solegendary.reignofnether.config.ReignOfNetherClientConfigs;
 import com.solegendary.reignofnether.cursor.CursorClientEvents;
 import com.solegendary.reignofnether.fogofwar.FogOfWarClientEvents;
 import com.solegendary.reignofnether.guiscreen.TopdownGui;
@@ -864,6 +865,17 @@ public class MinimapClientEvents {
         float dx = (worldX - xc_world) / pixelsToBlocks;
         float dz = (worldZ - zc_world) / pixelsToBlocks;
 
+        if (ReignOfNetherClientConfigs.SQUARE_MINIMAP.get()) {
+            // square mode: same -45° rotation as the diamond, but with the rotated quad
+            // circumscribing the visible square (content zoom = SQUARE_CONTENT_SCALE)
+            Vec2 rotated = MyMath.rotateCoords(
+                (float) (dx / Math.sqrt(2) * SQUARE_CONTENT_SCALE),
+                (float) (dz / Math.sqrt(2) * SQUARE_CONTENT_SCALE),
+                -45
+            );
+            return new Vec2(xc + rotated.x, yc + rotated.y);
+        }
+
         // rotate -45° to go from axis-aligned → diamond orientation
         Vec2 rotated = MyMath.rotateCoords((float) (dx / Math.sqrt(2)), (float) (dz / Math.sqrt(2)), -45);
 
@@ -932,6 +944,11 @@ public class MinimapClientEvents {
         yc = MC.getWindow().getGuiScaledHeight() - mapGuiRadius - CORNER_OFFSET;
         yb = MC.getWindow().getGuiScaledHeight() - CORNER_OFFSET;
 
+        if (ReignOfNetherClientConfigs.SQUARE_MINIMAP.get()) {
+            renderSquareMap(guiGraphics, matrix4f);
+            return;
+        }
+
         // background vertex coords need to be slightly larger
         float xl_bg = xl - BG_OFFSET;
         float xc_bg = xc;
@@ -968,10 +985,71 @@ public class MinimapClientEvents {
         buffer.endBatch();
     }
 
+    public static final float SQUARE_SCALE = 1.2f; // 20% bigger than the inscribed square
+    public static float squareHalf = 0; // half-side of the visible square, set per frame
+    // content-zoom factor for square mode: 2 * SQUARE_SCALE / sqrt(2) — chosen so the rotated
+    // (-45°) texture quad circumscribes the visible square (no empty corners after scissor)
+    public static final float SQUARE_CONTENT_SCALE = (float) (SQUARE_SCALE * Math.sqrt(2));
+
+    private static void renderSquareMap(GuiGraphics guiGraphics, Matrix4f matrix4f) {
+        float baseHalf = (float) (mapGuiRadius / Math.sqrt(2));
+        float half = baseHalf * SQUARE_SCALE;
+        squareHalf = half;
+
+        // anchor bottom-right corner at the very bottom-right of the screen
+        int sw = MC.getWindow().getGuiScaledWidth();
+        int sh = MC.getWindow().getGuiScaledHeight();
+        float brX = sw - CORNER_OFFSET;
+        float brY = sh - CORNER_OFFSET;
+        // centre of the bigger square (grows up-left from the fixed bottom-right)
+        xc = brX - half;
+        yc = brY - half;
+
+        float x1 = brX - 2 * half;
+        float x2 = brX;
+        float y1 = brY - 2 * half;
+        float y2 = brY;
+
+        // parchment frame: same texture as the diamond — the artwork is a square frame drawn
+        // axis-aligned in the image, so standard (0,0)→(1,1) UVs render it as-is here.
+        float xl_bg = x1 - BG_OFFSET, xr_bg = x2 + BG_OFFSET;
+        float yt_bg = y1 - BG_OFFSET, yb_bg = y2 + BG_OFFSET;
+        ResourceLocation bg = ResourceLocation.fromNamespaceAndPath(
+                ReignOfNether.MOD_ID, "textures/hud/map_background.png");
+        RenderSystem.setShaderTexture(0, bg);
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        BufferBuilder bb = Tesselator.getInstance().getBuilder();
+        bb.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+        bb.vertex(matrix4f, xl_bg, yb_bg, 0.0F).uv(0.0F, 1.0F).endVertex();
+        bb.vertex(matrix4f, xr_bg, yb_bg, 0.0F).uv(1.0F, 1.0F).endVertex();
+        bb.vertex(matrix4f, xr_bg, yt_bg, 0.0F).uv(1.0F, 0.0F).endVertex();
+        bb.vertex(matrix4f, xl_bg, yt_bg, 0.0F).uv(0.0F, 0.0F).endVertex();
+        BufferUploader.drawWithShader(bb.end());
+
+        // clip the rotated content to the visible square (after the frame, so frame isn't clipped)
+        guiGraphics.enableScissor((int) x1, (int) y1, (int) x2, (int) y2);
+
+        // render the texture as a rotated quad that fully circumscribes the visible square
+        // (d = 2*half makes the diamond's edges meet the square's corners — no black borders)
+        float d = 2 * half;
+        MultiBufferSource.BufferSource buffer = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
+        VertexConsumer consumer = buffer.getBuffer(mapRenderType);
+        consumer.vertex(matrix4f, xc, yc + d, 0.0F).color(255, 255, 255, 255).uv(0.0F, 1.0F).uv2(255).endVertex();
+        consumer.vertex(matrix4f, xc + d, yc, 0.0F).color(255, 255, 255, 255).uv(1.0F, 1.0F).uv2(255).endVertex();
+        consumer.vertex(matrix4f, xc, yc - d, 0.0F).color(255, 255, 255, 255).uv(1.0F, 0.0F).uv2(255).endVertex();
+        consumer.vertex(matrix4f, xc - d, yc, 0.0F).color(255, 255, 255, 255).uv(0.0F, 0.0F).uv2(255).endVertex();
+        buffer.endBatch();
+
+        guiGraphics.disableScissor();
+    }
+
     // https://stackoverflow.com/questions/27022064/detect-click-in-a-diamond
     public static boolean isPointInsideMinimap(double x, double y) {
         double dx = Math.abs(x - xc);
         double dy = Math.abs(y - yc);
+        if (ReignOfNetherClientConfigs.SQUARE_MINIMAP.get()) {
+            return dx <= squareHalf && dy <= squareHalf;
+        }
         double d = dx / (mapGuiRadius * 2) + dy / (mapGuiRadius * 2);
         return d <= 0.5;
     }
@@ -992,10 +1070,19 @@ public class MinimapClientEvents {
             x -= radius * Math.cos(angleRad);
             y -= radius * Math.sin(angleRad);
         }
-        Vec2 clicked = MyMath.rotateCoords(x - xc, y - yc, 45);
 
-        double xWorld = xc_world + clicked.x * pixelsToBlocks * Math.sqrt(2);
-        double zWorld = zc_world + clicked.y * pixelsToBlocks * Math.sqrt(2);
+        double xWorld;
+        double zWorld;
+        if (ReignOfNetherClientConfigs.SQUARE_MINIMAP.get()) {
+            // square mode: undo -45° rotation and SQUARE_CONTENT_SCALE
+            Vec2 clicked = MyMath.rotateCoords(x - xc, y - yc, 45);
+            xWorld = xc_world + clicked.x * pixelsToBlocks * Math.sqrt(2) / SQUARE_CONTENT_SCALE;
+            zWorld = zc_world + clicked.y * pixelsToBlocks * Math.sqrt(2) / SQUARE_CONTENT_SCALE;
+        } else {
+            Vec2 clicked = MyMath.rotateCoords(x - xc, y - yc, 45);
+            xWorld = xc_world + clicked.x * pixelsToBlocks * Math.sqrt(2);
+            zWorld = zc_world + clicked.y * pixelsToBlocks * Math.sqrt(2);
+        }
         int roundedX = Mth.floor(xWorld + 0.5d);
         int roundedZ = Mth.floor(zWorld + 0.5d);
         int roundedY = MiscUtil.getHighestNonAirBlock(MC.level, new BlockPos(roundedX, 0, roundedZ)).getY();

--- a/src/main/java/com/solegendary/reignofnether/time/TimeClientEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/time/TimeClientEvents.java
@@ -2,6 +2,7 @@ package com.solegendary.reignofnether.time;
 
 import com.solegendary.reignofnether.ReignOfNether;
 import com.solegendary.reignofnether.building.addon.RangeIndicatorAddon;
+import com.solegendary.reignofnether.config.ReignOfNetherClientConfigs;
 import com.solegendary.reignofnether.guiscreen.TopdownGui;
 import com.solegendary.reignofnether.hud.Button;
 import com.solegendary.reignofnether.minimap.MinimapClientEvents;
@@ -113,15 +114,31 @@ public class TimeClientEvents {
         }
 
         if (!isBloodMoonActive()) {
-            xPos = MC.getWindow().getGuiScaledWidth() - MinimapClientEvents.getMapGuiRadius() - (
-                    MinimapClientEvents.CORNER_OFFSET * 2
-            ) + 2;
-            yPos = MC.getWindow().getGuiScaledHeight() - (MinimapClientEvents.getMapGuiRadius() * 2) - (
-                    MinimapClientEvents.CORNER_OFFSET * 2
-            ) - 6;
-
+            updateClockPos();
             evt.getGuiGraphics().renderItem(new ItemStack(Items.CLOCK), xPos, yPos);
             evt.getGuiGraphics().renderItemDecorations(MC.font, new ItemStack(Items.CLOCK), xPos, yPos);
+        }
+    }
+
+    private static void updateClockPos() {
+        int screenWidth = MC.getWindow().getGuiScaledWidth();
+        int screenHeight = MC.getWindow().getGuiScaledHeight();
+        int radius = MinimapClientEvents.getMapGuiRadius();
+        int co = MinimapClientEvents.CORNER_OFFSET;
+        if (ReignOfNetherClientConfigs.SQUARE_MINIMAP.get()) {
+            // clock centred ON the top-left corner of the visible square (half in / half out)
+            float baseHalf = (float) (radius / Math.sqrt(2));
+            float half = baseHalf * MinimapClientEvents.SQUARE_SCALE;
+            float brX = screenWidth - co;
+            float brY = screenHeight - co;
+            float tlX = brX - 2 * half;  // top-left corner X
+            float tlY = brY - 2 * half;  // top-left corner Y
+            // 16x16 clock nudged a few px up-left from the corner
+            xPos = (int) (tlX - 12);
+            yPos = (int) (tlY - 12);
+        } else {
+            xPos = screenWidth - radius - (co * 2) + 2;
+            yPos = screenHeight - (radius * 2) - (co * 2) - 6;
         }
     }
 
@@ -132,12 +149,7 @@ public class TimeClientEvents {
             return;
         }
 
-        xPos = MC.getWindow().getGuiScaledWidth() - MinimapClientEvents.getMapGuiRadius() - (
-            MinimapClientEvents.CORNER_OFFSET * 2
-        ) + 2;
-        yPos = MC.getWindow().getGuiScaledHeight() - (MinimapClientEvents.getMapGuiRadius() * 2) - (
-            MinimapClientEvents.CORNER_OFFSET * 2
-        ) - 6;
+        updateClockPos();
 
         bloodMoonButton = getBloodMoonButton();
         if (!bloodMoonButton.isHidden.get() && evt.getScreen() instanceof TopdownGui) {


### PR DESCRIPTION
Adds a client config toggle (Mods → Reign of Nether → Config → Minimap)
to switch the minimap from the default diamond to a square layout

When square mode is on:
- map content stays rotated 45° to match the camera view
- minimap controls move to a 5×2 button grid on the left side, bottom
  aligned with the map (out of the way, no more overlap)
- clock sits on the top-right corner of the map

Diamond mode is untouched, players who don't enable the toggle see no
difference.