### PR TITLE
Speed up RTS pathfinding ~10x and fix worker mining lag

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/mixin/LevelChunkMixin.java
+++ b/src/main/java/com/solegendary/reignofnether/mixin/LevelChunkMixin.java
@@ -1,5 +1,6 @@
 package com.solegendary.reignofnether.mixin;
 
+import com.solegendary.reignofnether.resources.ResourceIndex;
 import com.solegendary.reignofnether.unit.pathfinding.WalkabilityGrid;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -24,5 +25,6 @@ public abstract class LevelChunkMixin {
     private void reignofnether$invalidateWalkability(BlockPos pos, BlockState state, boolean isMoving,
                                                      CallbackInfoReturnable<BlockState> cir) {
         WalkabilityGrid.markColumnDirtyIfPresent(getLevel(), pos);
+        ResourceIndex.onBlockChange(getLevel(), pos, state);
     }
 }

--- a/src/main/java/com/solegendary/reignofnether/mixin/LevelChunkMixin.java
+++ b/src/main/java/com/solegendary/reignofnether/mixin/LevelChunkMixin.java
@@ -11,9 +11,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-// Invalidate the walkability column on any loaded-chunk block change, on both client and server.
-// LevelChunk.setBlockState is the single chokepoint every such change funnels through (worldgen uses
-// ProtoChunk, so this never fires during generation).
+// Mark the walkability column dirty on any loaded-chunk block change, on both client and server (the
+// server-side grid is the one the pathfinder reads; client has no grid so it no-ops). LevelChunk.setBlockState
+// is the single chokepoint every such change funnels through (worldgen uses ProtoChunk, so this never fires
+// during generation). Marking (not evicting) keeps the chunk readable until the deferred drain patches it.
 @Mixin(LevelChunk.class)
 public abstract class LevelChunkMixin {
 
@@ -22,6 +23,6 @@ public abstract class LevelChunkMixin {
     @Inject(method = "setBlockState", at = @At("TAIL"))
     private void reignofnether$invalidateWalkability(BlockPos pos, BlockState state, boolean isMoving,
                                                      CallbackInfoReturnable<BlockState> cir) {
-        WalkabilityGrid.invalidateColumnIfPresent(getLevel(), pos);
+        WalkabilityGrid.markColumnDirtyIfPresent(getLevel(), pos);
     }
 }

--- a/src/main/java/com/solegendary/reignofnether/resources/ResourceChunk.java
+++ b/src/main/java/com/solegendary/reignofnether/resources/ResourceChunk.java
@@ -1,0 +1,30 @@
+package com.solegendary.reignofnether.resources;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+
+import java.util.EnumMap;
+
+// Resource block positions in one chunk, bucketed by type, as packed BlockPos.asLong world positions.
+// Server-main-thread only, so no synchronisation. A LongOpenHashSet (not a list) because block changes do
+// O(1) add/remove BY VALUE (a block mined/placed anywhere in the chunk) and we must never store a position
+// twice (a re-scan after eviction, or a place onto an already-indexed spot, would otherwise duplicate).
+// Iteration order is irrelevant - ResourceIndex.findClosest re-sorts candidates by distance.
+public final class ResourceChunk {
+    // Only FOOD / WOOD / ORE ever get a bucket; NONE is never indexed.
+    private final EnumMap<ResourceName, LongOpenHashSet> buckets = new EnumMap<>(ResourceName.class);
+
+    public void add(ResourceName type, long packed) {
+        buckets.computeIfAbsent(type, k -> new LongOpenHashSet()).add(packed);
+    }
+
+    // Remove this position from every bucket - on a block change we don't know its previous resource type.
+    public void removeAll(long packed) {
+        for (LongOpenHashSet set : buckets.values())
+            set.remove(packed);
+    }
+
+    // The positions of one resource type, or null if none indexed for it.
+    public LongOpenHashSet positions(ResourceName type) {
+        return buckets.get(type);
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/resources/ResourceIndex.java
+++ b/src/main/java/com/solegendary/reignofnether/resources/ResourceIndex.java
@@ -1,0 +1,195 @@
+package com.solegendary.reignofnether.resources;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrays;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.function.Predicate;
+
+// Per-chunk spatial index of resource block positions, so a worker's resource search iterates only the
+// actual resources in nearby chunks instead of brute-force scanning a range^3 cube (the BlockPos
+// .findClosestMatch hotspot). Used and maintained entirely on the SERVER MAIN THREAD (the gather goal,
+// the LevelChunk.setBlockState mixin, and the server tick), so - unlike WalkabilityGrid, which is read by
+// A* worker threads - there is NO cross-thread access and block changes mutate the live chunk set in place.
+// Deferral (the budgeted build queue) is needed only for the expensive cold full-chunk scan.
+public final class ResourceIndex {
+    public static final int MAX_INDEXED_CHUNKS = 2048;            // LRU cap; a ResourceChunk is light (longs only)
+    public static final int MAX_RESOURCE_CHUNK_SCANS_PER_TICK = 8; // cold-scan budget per server tick
+
+    private static final WeakHashMap<LevelAccessor, ResourceIndex> PER_LEVEL = new WeakHashMap<>();
+
+    // Cold-scan queue: chunks awaiting a budgeted full scan. Global across levels, main-thread only; holds a
+    // strong Level ref only while a scan is pending. Dedup is guarded per-index by `queued`.
+    private record PendingScan(Level level, long chunkKey) {}
+    private static final ArrayDeque<PendingScan> BUILD_QUEUE = new ArrayDeque<>();
+
+    // Access-ordered LRU (head = most-recently-used). A present value means the chunk has been scanned.
+    private final Long2ObjectLinkedOpenHashMap<ResourceChunk> chunks = new Long2ObjectLinkedOpenHashMap<>();
+    // Chunk keys currently sitting in BUILD_QUEUE for this index, so the same chunk is never enqueued twice.
+    private final LongOpenHashSet queued = new LongOpenHashSet();
+
+    private ResourceIndex() {}
+
+    public static synchronized ResourceIndex get(LevelAccessor level) {
+        return PER_LEVEL.computeIfAbsent(level, k -> new ResourceIndex());
+    }
+
+    // Peek without creating an index - used by the client mixin path so the client never builds one.
+    private static synchronized ResourceIndex peek(LevelAccessor level) {
+        return PER_LEVEL.get(level);
+    }
+
+    // Synchronous O(1) maintenance on every server-side loaded-chunk block change (from LevelChunkMixin).
+    // No-op on the client (no index) and for not-yet-scanned chunks (their eventual cold scan reads live
+    // state). Classifies the NEW state: resource -> ensure it's in the right bucket; otherwise drop it.
+    public static void onBlockChange(Level level, BlockPos pos, BlockState newState) {
+        if (level == null || pos == null) return;
+        ResourceIndex idx = peek(level);
+        if (idx == null) return;
+        long chunkKey = ChunkPos.asLong(pos.getX() >> 4, pos.getZ() >> 4);
+        ResourceChunk rc = idx.chunks.get(chunkKey);
+        if (rc == null) return; // chunk not indexed -> ignore; the cold scan captures current state later
+        long packed = pos.asLong();
+        ResourceSource src = ResourceSources.getFromBlockState(newState); // type-only; blockStateTest at query
+        rc.removeAll(packed); // drop any stale entry first (mine-to-air, or a resource->resource type swap)
+        if (src != null && src.resourceName != ResourceName.NONE)
+            rc.add(src.resourceName, packed);
+    }
+
+    // Closest valid resource of `type` within the [-range,range] box around origin (matching the old
+    // findClosestMatch(origin, range, range, cond) bounding box), filtered by `condition`. Lazily queues any
+    // in-range un-indexed chunk for a cold scan and proceeds with whatever IS indexed this tick.
+    public Optional<BlockPos> findClosest(Level level, BlockPos origin, int range,
+                                          ResourceName type, Predicate<BlockPos> condition) {
+        if (type == null || type == ResourceName.NONE) return Optional.empty();
+
+        final int ox = origin.getX(), oy = origin.getY(), oz = origin.getZ();
+        final int cx0 = (ox - range) >> 4, cx1 = (ox + range) >> 4;
+        final int cz0 = (oz - range) >> 4, cz1 = (oz + range) >> 4;
+
+        LongArrayList cand = new LongArrayList();
+        for (int cx = cx0; cx <= cx1; cx++) {
+            for (int cz = cz0; cz <= cz1; cz++) {
+                long ckey = ChunkPos.asLong(cx, cz);
+                ResourceChunk rc = chunks.getAndMoveToFirst(ckey);
+                if (rc == null) { enqueueIfNeeded(level, ckey); continue; }
+                LongOpenHashSet set = rc.positions(type);
+                if (set == null || set.isEmpty()) continue;
+                for (LongIterator it = set.iterator(); it.hasNext();) {
+                    long p = it.nextLong();
+                    if (Math.abs(BlockPos.getX(p) - ox) > range
+                            || Math.abs(BlockPos.getY(p) - oy) > range
+                            || Math.abs(BlockPos.getZ(p) - oz) > range) continue;
+                    cand.add(p);
+                }
+            }
+        }
+        if (cand.isEmpty()) return Optional.empty();
+
+        // Sort nearest-first so condition runs in increasing-distance order (preserving findClosestMatch's
+        // "first passing wins", and the altSearchPos side-effect in BLOCK_CONDITION firing on the NEAREST
+        // contested block). Candidate count is small (resources in a handful of chunks).
+        long[] arr = cand.toLongArray();
+        LongArrays.quickSort(arr, (a, b) -> Long.compare(distSq(a, ox, oy, oz), distSq(b, ox, oy, oz)));
+        for (long p : arr) {
+            BlockPos bp = new BlockPos(BlockPos.getX(p), BlockPos.getY(p), BlockPos.getZ(p));
+            if (condition.test(bp)) return Optional.of(bp);
+        }
+        return Optional.empty();
+    }
+
+    private void enqueueIfNeeded(Level level, long chunkKey) {
+        if (chunks.containsKey(chunkKey) || queued.contains(chunkKey)) return;
+        queued.add(chunkKey);
+        BUILD_QUEUE.add(new PendingScan(level, chunkKey));
+    }
+
+    // Drop the chunk's index + pending scan on unload, so stale positions can't linger and the queue can't
+    // pin an unloaded chunk's Level. A reload re-scans fresh.
+    public static void onChunkUnload(Level level, ChunkPos cp) {
+        if (level == null || level.isClientSide()) return;
+        ResourceIndex idx = peek(level);
+        if (idx == null) return;
+        long key = cp.toLong();
+        idx.chunks.remove(key);
+        idx.queued.remove(key);
+    }
+
+    // Budgeted cold scans, called from PathfinderWorkerPool.onServerTick START phase.
+    public static void drainBuildQueue(int budget) {
+        int done = 0;
+        while (done < budget && !BUILD_QUEUE.isEmpty()) {
+            PendingScan ps = BUILD_QUEUE.poll();
+            ResourceIndex idx = peek(ps.level());
+            if (idx == null) continue;
+            if (!idx.queued.remove(ps.chunkKey())) continue;     // unloaded/cancelled since enqueue
+            if (idx.chunks.containsKey(ps.chunkKey())) continue; // already scanned via another path
+            LevelChunk chunk = loadedChunkOrNull(ps.level(), ps.chunkKey());
+            if (chunk == null) continue;                          // unloaded mid-queue
+            ResourceChunk rc = scanChunk(chunk);
+            idx.chunks.putAndMoveToFirst(ps.chunkKey(), rc);
+            while (idx.chunks.size() > MAX_INDEXED_CHUNKS) idx.chunks.removeLast();
+            done++;
+        }
+    }
+
+    // Scan one loaded chunk's resources, palette-aware. Most sections (stone/air) die at the palette check;
+    // only resource-bearing sections walk their 4096 cells. Captures worldgen resources (the setBlockState
+    // mixin never fires during worldgen, which uses ProtoChunk).
+    private static ResourceChunk scanChunk(LevelChunk chunk) {
+        ResourceChunk rc = new ResourceChunk();
+        final int baseX = chunk.getPos().getMinBlockX();
+        final int baseZ = chunk.getPos().getMinBlockZ();
+        LevelChunkSection[] sections = chunk.getSections();
+        for (int si = 0; si < sections.length; si++) {
+            LevelChunkSection section = sections[si];
+            if (section == null || section.hasOnlyAir()) continue;
+            if (!section.getStates().maybeHas(ResourceIndex::isResource)) continue; // palette-only pre-check
+            int sectionBaseY = SectionPos.sectionToBlockCoord(chunk.getSectionYFromSectionIndex(si));
+            for (int ly = 0; ly < 16; ly++)
+                for (int lz = 0; lz < 16; lz++)
+                    for (int lx = 0; lx < 16; lx++) {
+                        BlockState bs = section.getBlockState(lx, ly, lz);
+                        ResourceSource s = ResourceSources.getFromBlockState(bs);
+                        if (s == null || s.resourceName == ResourceName.NONE) continue;
+                        rc.add(s.resourceName, BlockPos.asLong(baseX + lx, sectionBaseY + ly, baseZ + lz));
+                    }
+        }
+        return rc;
+    }
+
+    private static boolean isResource(BlockState bs) {
+        ResourceSource s = ResourceSources.getFromBlockState(bs);
+        return s != null && s.resourceName != ResourceName.NONE;
+    }
+
+    private static LevelChunk loadedChunkOrNull(Level level, long key) {
+        if (!(level instanceof ServerLevel sl)) return null;
+        return sl.getChunkSource().getChunkNow(ChunkPos.getX(key), ChunkPos.getZ(key)); // never force-loads
+    }
+
+    private static long distSq(long p, int ox, int oy, int oz) {
+        long dx = BlockPos.getX(p) - ox, dy = BlockPos.getY(p) - oy, dz = BlockPos.getZ(p) - oz;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    // Server stop: drop the queue + per-level indices so static state can't pin Levels across a restart.
+    public static void clearAll() {
+        BUILD_QUEUE.clear();
+        synchronized (ResourceIndex.class) { PER_LEVEL.clear(); }
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/resources/ResourceIndexEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/resources/ResourceIndexEvents.java
@@ -1,0 +1,21 @@
+package com.solegendary.reignofnether.resources;
+
+import com.solegendary.reignofnether.ReignOfNether;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.event.level.ChunkEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+// Server-side chunk eviction for the resource index. Chunks are scanned lazily on demand (when a worker's
+// findClosest touches an un-indexed in-range chunk), like the walkability grid - so we only need to drop a
+// chunk's index when it unloads. @Mod.EventBusSubscriber self-registers (same style as PathfinderWorkerPool).
+@Mod.EventBusSubscriber(modid = ReignOfNether.MOD_ID)
+public final class ResourceIndexEvents {
+    private ResourceIndexEvents() {}
+
+    @SubscribeEvent
+    public static void onChunkUnload(ChunkEvent.Unload evt) {
+        if (evt.getLevel() instanceof Level lvl && !lvl.isClientSide())
+            ResourceIndex.onChunkUnload(lvl, evt.getChunk().getPos());
+    }
+}

--- a/src/main/java/com/solegendary/reignofnether/resources/ResourceSources.java
+++ b/src/main/java/com/solegendary/reignofnether/resources/ResourceSources.java
@@ -22,7 +22,6 @@ import net.minecraftforge.common.IPlantable;
 
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class ResourceSources {
 
@@ -64,9 +63,11 @@ public class ResourceSources {
             for (ResourceSource resourceSource : resourceSources)
                 if (resourceSource.validBlocks.contains(block))
                     return resourceSource;
-        if (bs.getTags().collect(Collectors.toSet()).contains(BlockTags.LOGS))
+        // bs.is(tag) is an O(1) membership test; the old getTags().collect(toSet()).contains(...) allocated a
+        // Set on every call - brutal when ResourceIndex's chunk scan runs this per cell of a resource section.
+        if (bs.is(BlockTags.LOGS))
             return GENERIC_LOG_BLOCK;
-        if (bs.getTags().collect(Collectors.toSet()).contains(BlockTags.LEAVES))
+        if (bs.is(BlockTags.LEAVES))
             return GENERIC_LEAVES_BLOCK;
         return null;
     }
@@ -76,9 +77,9 @@ public class ResourceSources {
             for (ResourceSource resourceSource : resourceSources)
                 if (resourceSource.validBlocks.contains(bs.getBlock()))
                     return resourceSource;
-        if (bs.getTags().collect(Collectors.toSet()).contains(BlockTags.LOGS))
+        if (bs.is(BlockTags.LOGS))
             return GENERIC_LOG_BLOCK;
-        if (bs.getTags().collect(Collectors.toSet()).contains(BlockTags.LEAVES))
+        if (bs.is(BlockTags.LEAVES))
             return GENERIC_LEAVES_BLOCK;
         return null;
     }

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/GatherResourcesGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/GatherResourcesGoal.java
@@ -47,6 +47,9 @@ public class GatherResourcesGoal extends MoveToTargetBlockGoal {
     public TargetResourcesSave permSaveData = new TargetResourcesSave();
 
     private static final int REACH_RANGE = 5;
+    // How far below a resource block a worker may stand and still reach it: mining reach is REACH_RANGE (3D),
+    // so standing ~4 below an adjacent column keeps it in range (sqrt(1^2 + 4^2) < 5).
+    private static final int MAX_REACH_DOWN = 4;
     private static final int DEFAULT_MAX_GATHER_TICKS = 600; // ticks to gather blocks - actual ticks may be lower, depending on the ResourceSource targeted
     private float gatherTicksLeft = DEFAULT_MAX_GATHER_TICKS;
     private static final int MAX_SEARCH_CD_TICKS = 40; // while idle, worker will look for a new block once every this number of ticks (searching is expensive!)
@@ -100,6 +103,12 @@ public class GatherResourcesGoal extends MoveToTargetBlockGoal {
             }
         }
         if (!hasClearNeighbour)
+            return false;
+
+        // must have a cell a worker can actually STAND in (floor below, head clear) within mining reach -
+        // rejects blocks suspended high off the ground (upper tree logs/leaves) that have air neighbours but
+        // no nearby ground, which the worker can never path up to and would just stall beneath.
+        if (!hasReachableStandSpot(bp))
             return false;
 
         // not targeted by another nearby worker
@@ -179,9 +188,8 @@ public class GatherResourcesGoal extends MoveToTargetBlockGoal {
                 else {
                     Optional<BlockPos> bpOpt;
                     if (altSearchPos != null) {
-                        bpOpt = BlockPos.findClosestMatch(
-                                altSearchPos, REACH_RANGE/2, REACH_RANGE/2,
-                            BLOCK_CONDITION);
+                        bpOpt = ResourceIndex.get(mob.level()).findClosest(
+                                mob.level(), altSearchPos, REACH_RANGE / 2, data.targetResourceName, BLOCK_CONDITION);
                         altSearchPos = null;
                     }
                     else {
@@ -193,12 +201,13 @@ public class GatherResourcesGoal extends MoveToTargetBlockGoal {
                             ticksIdle += 200;
                         }
 
-                        bpOpt = BlockPos.findClosestMatch(
+                        bpOpt = ResourceIndex.get(mob.level()).findClosest(
+                            mob.level(),
                             new BlockPos(
                                     (int) mob.getEyePosition().x,
                                     (int) mob.getEyePosition().y,
                                     (int) mob.getEyePosition().z
-                            ), range, range,
+                            ), range, data.targetResourceName,
                             BLOCK_CONDITION);
                     }
 
@@ -405,6 +414,25 @@ public class GatherResourcesGoal extends MoveToTargetBlockGoal {
         data.targetFarm = saveData.targetFarm;
     }
 
+
+    // True if a worker can stand somewhere adjacent to bp (within mining reach) to gather it: a cell with a
+    // solid floor below and clear feet+head, in one of the 4 cardinal neighbour columns across a vertical band
+    // from one above down to MAX_REACH_DOWN below. A block high in the air (no ground in any neighbour column)
+    // fails - that's the "very high tree" case. Checked nearest-first in BLOCK_CONDITION, so a reachable base
+    // log usually passes immediately and we rarely scan the full band.
+    private boolean hasReachableStandSpot(BlockPos bp) {
+        var level = mob.level();
+        for (BlockPos side : List.of(bp.north(), bp.south(), bp.east(), bp.west())) {
+            for (int dy = 1; dy >= -MAX_REACH_DOWN; dy--) {
+                BlockPos feet = side.above(dy); // above(negative) = below
+                if (!MiscUtil.isSolidBlocking(level, feet)
+                        && !MiscUtil.isSolidBlocking(level, feet.above())
+                        && MiscUtil.isSolidBlocking(level, feet.below()))
+                    return true;
+            }
+        }
+        return false;
+    }
 
     private boolean isBlockInRange(BlockPos target) {
         int reachRangeBonus = (int) Math.min(5, ticksWithoutTarget / TICK_CD);

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
@@ -86,12 +86,17 @@ public class MoveToTargetBlockGoal extends Goal {
             this.mob.getOnPos().distSqr(moveTarget) > getMinDistToRecalculateSqr()) {
             BlockPos oldFinalNode = getFinalNodePos();
             this.start();
-            BlockPos newFinalNode = getFinalNodePos();
-            // start() is very expensive, and it repeats every tick if the mob is stuck, eg. targeting over water
-            if (oldFinalNode != null && oldFinalNode.equals(newFinalNode))
-                backoffRecalcCooldown();
-            else
-                resetRecalcBackoff();
+            // start() is very expensive, and it repeats every tick if the mob is stuck, eg. targeting over water.
+            // For the async RTS path the result isn't ready yet (start() just stopped navigation and fired the
+            // request), so the final node here is meaningless - onPathReady owns the backoff once it knows
+            // whether the target was reachable. Only the synchronous vanilla path has a final node to compare.
+            if (!pathPending) {
+                BlockPos newFinalNode = getFinalNodePos();
+                if (oldFinalNode != null && oldFinalNode.equals(newFinalNode))
+                    backoffRecalcCooldown();
+                else
+                    resetRecalcBackoff();
+            }
             return true;
         }
         else if (moveTarget == null)
@@ -161,10 +166,22 @@ public class MoveToTargetBlockGoal extends Goal {
             this.mob.getNavigation().stop();
             return;
         }
+        // Reachability sets the retry cadence. A reachable path resets the backoff (prompt re-path so a long
+        // journey keeps chaining). An unreachable result (null, or a partial that can't reach) escalates the
+        // exponential backoff and sets a real cooldown, so a stuck unit stops re-requesting a full cold-corridor
+        // path every async round-trip - the spiral that pinned the main thread. setMoveTarget resets the backoff
+        // when the target changes, so escalation only persists while hammering the SAME unreachable target.
+        if (path != null && path.canReach()) {
+            resetRecalcBackoff();
+        } else {
+            backoffRecalcCooldown();
+            recalcCooldown = currentRecalcCooldown;
+        }
         if (path == null) {
             this.mob.getNavigation().stop();
             return;
         }
+        // Follow even a partial (unreachable) path so the unit still makes progress toward the target.
         this.mob.getNavigation().moveTo(path, Unit.getSpeedModifier(u));
         if (!this.mob.level().isClientSide()) {
             byte type = path.canReach() ? RtsPathfinder.TYPE_ASTAR : RtsPathfinder.TYPE_FAILED;
@@ -176,8 +193,11 @@ public class MoveToTargetBlockGoal extends Goal {
         if (bp != null) {
             MiscUtil.addUnitCheckpoint((Unit) mob, bp, true);
         }
+        // Only reset the unreachable-target backoff when the target actually changes, so a goal re-asserting the
+        // SAME (possibly unreachable) target can't clobber the escalating backoff that onPathReady builds up.
+        if (!java.util.Objects.equals(bp, this.moveTarget))
+            resetRecalcBackoff();
         this.moveTarget = bp;
-        resetRecalcBackoff();
 
         if (!this.mob.level().isClientSide())
             this.start();

--- a/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/goals/MoveToTargetBlockGoal.java
@@ -38,7 +38,16 @@ public class MoveToTargetBlockGoal extends Goal {
     protected void resetRecalcBackoff() { currentRecalcCooldown = RECALC_COOLDOWN_MAX; }
     public boolean isInBackoff() { return currentRecalcCooldown > RECALC_COOLDOWN_MAX && moveTarget != null; }
     protected int recalcCooldown = 0; // limit start() used by canContinueToUse
+    // Endpoint (nearest-reachable cell) of the last computed path. A re-path that returns the SAME endpoint
+    // means the unit has arrived at the best reachable spot and recomputing won't improve it - the only case
+    // worth throttling. An endpoint that MOVED means it's still travelling (a long journey delivered in
+    // chained segments), so recompute promptly. Reset on a target change / stop so a fresh target starts clean.
+    @Nullable protected BlockPos lastFinalNode = null;
     protected boolean pathPending = false; // true while an async RTS path request is in flight
+    // Bumped on every new request, order, or stop. The async callback captures this at request time and drops
+    // its result if it no longer matches - so a slow stale path (eg. a long FAR route that finishes computing
+    // after we've already been re-ordered to go NEAR) can't overwrite the newer order.
+    protected int pathRequestSeq = 0;
 
     public MoveToTargetBlockGoal(Mob mob, boolean persistent, int reachRange) {
         this.mob = mob;
@@ -127,7 +136,8 @@ public class MoveToTargetBlockGoal extends Goal {
             this.mob.getNavigation().stop();
             MobilityClass mobility = MobilityClass.of(u);
             pathPending = true;
-            RtsPathfinder.requestPath(this.mob, moveTarget, moveReachRange, mobility, this::onPathReady);
+            final int seq = ++pathRequestSeq;
+            RtsPathfinder.requestPath(this.mob, moveTarget, moveReachRange, mobility, path -> onPathReady(path, seq));
             return;
         }
 
@@ -159,24 +169,35 @@ public class MoveToTargetBlockGoal extends Goal {
     }
 
     // Callback for the async RTS pathfinder. Runs on the server thread once a path is ready.
-    protected void onPathReady(@Nullable Path path) {
+    protected void onPathReady(@Nullable Path path, int seq) {
+        // A newer order/stop has superseded the request this result is for - drop it so the old order can't
+        // overwrite the new one. Leave pathPending alone: the newer request is still in flight and owns it.
+        if (seq != pathRequestSeq) return;
         pathPending = false;
         if (moveTarget == null) return;
         if (!(this.mob instanceof Unit u)) {
             this.mob.getNavigation().stop();
             return;
         }
-        // Reachability sets the retry cadence. A reachable path resets the backoff (prompt re-path so a long
-        // journey keeps chaining). An unreachable result (null, or a partial that can't reach) escalates the
-        // exponential backoff and sets a real cooldown, so a stuck unit stops re-requesting a full cold-corridor
-        // path every async round-trip - the spiral that pinned the main thread. setMoveTarget resets the backoff
-        // when the target changes, so escalation only persists while hammering the SAME unreachable target.
+        // Progress - not canReach() - sets the retry cadence. canReach() only asks "did A* land on the exact
+        // target tile within 1 vertical block", which is false for a mineable block (a log tile, or an upper
+        // log) even when snapToWalkable got the unit standing right next to it and mining. So we throttle on
+        // whether the nearest-reachable ENDPOINT is still improving: a re-path that returns the SAME endpoint
+        // means the unit arrived at the best reachable spot and recomputing won't help (the only case worth
+        // throttling - genuinely walled off, so stop hammering A*). An endpoint that MOVED (or the first path
+        // for this target) means it's still travelling - eg. a long journey delivered in chained segments - so
+        // recompute promptly and never freeze between segments. setMoveTarget clears lastFinalNode on a target
+        // change, so throttling only persists while genuinely stuck on the SAME target.
+        BlockPos newFinalNode = (path == null) ? null : getFinalNodePos(path);
         if (path != null && path.canReach()) {
             resetRecalcBackoff();
-        } else {
+        } else if (path != null && lastFinalNode != null && lastFinalNode.equals(newFinalNode)) {
             backoffRecalcCooldown();
             recalcCooldown = currentRecalcCooldown;
+        } else {
+            resetRecalcBackoff();
         }
+        lastFinalNode = newFinalNode;
         if (path == null) {
             this.mob.getNavigation().stop();
             return;
@@ -193,13 +214,21 @@ public class MoveToTargetBlockGoal extends Goal {
         if (bp != null) {
             MiscUtil.addUnitCheckpoint((Unit) mob, bp, true);
         }
-        // Only reset the unreachable-target backoff when the target actually changes, so a goal re-asserting the
-        // SAME (possibly unreachable) target can't clobber the escalating backoff that onPathReady builds up.
-        if (!java.util.Objects.equals(bp, this.moveTarget))
+        // Re-issuing the SAME target must NOT re-fire a path request. GatherResourcesGoal re-asserts its block
+        // target every tick (TICK_CD) for persistence; firing start() each time spammed snap-and-fail paths at
+        // solid resource blocks (the block search "asking units to stand on the block they mine"). So only an
+        // actual target CHANGE resets the backoff and starts a fresh path - and that change also bumps the
+        // request seq in start(), superseding any stale path still computing for the old target. A stall on an
+        // unchanged target is re-pathed by canContinueToUse under the backoff throttle, not by this per-tick call.
+        boolean changed = !java.util.Objects.equals(bp, this.moveTarget);
+        if (changed) {
             resetRecalcBackoff();
+            recalcCooldown = 0;
+            lastFinalNode = null;
+        }
         this.moveTarget = bp;
 
-        if (!this.mob.level().isClientSide())
+        if (changed && !this.mob.level().isClientSide())
             this.start();
     }
 
@@ -222,6 +251,9 @@ public class MoveToTargetBlockGoal extends Goal {
 
     public void stopMoving() {
         recalcCooldown = 0;
+        pathPending = false;
+        lastFinalNode = null;
+        pathRequestSeq++; // cancel any in-flight path so a late result can't restart movement after a stop.
         this.moveTarget = null;
         this.mob.getNavigation().stop();
         if (this.mob.isVehicle() && this.mob.getPassengers().get(0) instanceof Unit unit)

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/ChunkSnapshot.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/ChunkSnapshot.java
@@ -78,6 +78,12 @@ public final class ChunkSnapshot implements WalkabilityView {
     }
 
     @Override
+    public float crowdAt(int wx, int y, int wz) {
+        WalkabilityGridChunk c = chunkAt(wx, wz);
+        return c == null ? 0f : c.crowdAt(wx, y, wz);
+    }
+
+    @Override
     public MobilityClass mobility() { return mobility; }
 
     @Override

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/GridAStar.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/GridAStar.java
@@ -112,7 +112,7 @@ public final class GridAStar {
                 if (GridNeighbors.diagonalBlocked(view, mob, cur.x, ny, cur.z, DX[d], DZ[d])) continue;
 
                 float ng = cur.g + GridNeighbors.stepCost(d) * costMult;
-                ng += GridNeighbors.crowdingMalus(view, nx, ny, nz); // avoid walls/edges/corners for ALL units
+                ng += view.crowdAt(nx, ny, nz); // avoid walls/edges/corners for ALL units (precomputed in the chunk)
 
                 relax(all, open, nx, ny, nz, ng, gx, gy, gz, cur);
             }
@@ -149,7 +149,7 @@ public final class GridAStar {
                     int drop = cur.y - fy;
                     float ng = cur.g + GridNeighbors.stepCost(d) * lmult
                              + PathfinderConfig.FALL_COST_PER_BLOCK * drop
-                             + GridNeighbors.crowdingMalus(view, nx, fy, nz);
+                             + view.crowdAt(nx, fy, nz);
                     relax(all, open, nx, fy, nz, ng, gx, gy, gz, cur);
                     break;
                 }

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/GridNeighbors.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/GridNeighbors.java
@@ -71,8 +71,19 @@ public final class GridNeighbors {
     public static final float SIDE_MALUS = 0.75f; // touching a wall (distance-1); distance-2 is half this
     public static final float CORNER_MALUS = 0.375f; // extra "slight" cost for an inside 90-deg corner (L of walls)
 
+    // Reads one cell's body-blocking (solid) state. Lets crowdingMalus run either over a live WalkabilityView
+    // (A* / debug) or directly over a chunk's local solid[] array at build time, from ONE definition.
+    @FunctionalInterface
+    public interface SolidProbe { boolean solid(int x, int y, int z); }
+
+    // Adapter: the malus as A* and the debug overlay call it - over a live view, with the unit's clearance.
     public static float crowdingMalus(WalkabilityView view, int x, int y, int z) {
-        int clearance = view.clearanceCells();
+        return crowdingMalus(view::solidAt, view.clearanceCells(), x, y, z);
+    }
+
+    // The malus itself, over a solid-probe. crowdingMalus depends ONLY on surrounding solid cells + clearance,
+    // so the same code feeds both the live A* path and the precomputed per-cell crowd[] cache (build time).
+    public static float crowdingMalus(SolidProbe probe, int clearance, int x, int y, int z) {
         // HORIZONTAL cost is driven by the NEAREST wall, not a SUM over every wall. A cell touching a wall
         // (distance-1) pays full; a cell whose closest wall is one cell further (distance-2) pays half; a cell with
         // open space all around pays nothing. Summing every wall made the middle of a corridor - flanked by BOTH
@@ -87,7 +98,7 @@ public final class GridNeighbors {
         for (int dx = -1; dx <= 1; dx++)
             for (int dz = -1; dz <= 1; dz++) {
                 if (dx == 0 && dz == 0) continue;
-                if (wallBeside(view, x + dx, z + dz, y, clearance)) { wall = SIDE_MALUS; break distance1; }
+                if (wallBeside(probe, x + dx, z + dz, y, clearance)) { wall = SIDE_MALUS; break distance1; }
             }
         // distance-2 ring - half, only counts if nothing was touching at distance-1
         if (wall == 0f) {
@@ -95,21 +106,21 @@ public final class GridNeighbors {
             for (int dx = -2; dx <= 2; dx++)
                 for (int dz = -2; dz <= 2; dz++) {
                     if (Math.max(Math.abs(dx), Math.abs(dz)) != 2) continue; // only the distance-2 ring
-                    if (wallBeside(view, x + dx, z + dz, y, clearance)) { wall = SIDE_MALUS * 0.5f; break distance2; }
+                    if (wallBeside(probe, x + dx, z + dz, y, clearance)) { wall = SIDE_MALUS * 0.5f; break distance2; }
                 }
         }
         // Low ceiling right above the head - a separate, additive term. In a roofed tunnel this is uniform across
         // all cells so it cancels out in the A* comparison and the horizontal nearest-wall term still picks the
         // middle; where only some cells have a low ceiling it nudges the unit toward the headroom.
-        float ceiling = view.solidAt(x, y + clearance, z) ? SIDE_MALUS : 0f;
+        float ceiling = probe.solid(x, y + clearance, z) ? SIDE_MALUS : 0f;
         // Inner-edge penalty: a +1 block (raised terrain / step-up, or the base of a wall) on two ADJACENT sides
         // makes this cell an inside corner the unit would 45-degree step into. Make it less valuable so paths
         // don't zig-zag diagonally up step corners.
         float corner = 0f;
-        boolean rW = raisedBeside(view, x - 1, z, y);
-        boolean rE = raisedBeside(view, x + 1, z, y);
-        boolean rN = raisedBeside(view, x, z - 1, y);
-        boolean rS = raisedBeside(view, x, z + 1, y);
+        boolean rW = raisedBeside(probe, x - 1, z, y);
+        boolean rE = raisedBeside(probe, x + 1, z, y);
+        boolean rN = raisedBeside(probe, x, z - 1, y);
+        boolean rS = raisedBeside(probe, x, z + 1, y);
         if (rN && rW) corner += CORNER_MALUS;
         if (rN && rE) corner += CORNER_MALUS;
         if (rS && rW) corner += CORNER_MALUS;
@@ -125,15 +136,15 @@ public final class GridNeighbors {
     // climbable step ("block-air"), not a wall. But anything with a solid above feet counts as a wall even with a
     // 1-block air gap - a full 2-tall wall (y,y+1), an overhang ("air-block": air y, solid y+1), a wall lifted
     // off the ground (air y, solid y+1+), or a wall with a hole ("block-air-block": solid y, air y+1, solid y+2).
-    private static boolean wallBeside(WalkabilityView view, int cx, int cz, int y, int clearance) {
+    private static boolean wallBeside(SolidProbe probe, int cx, int cz, int y, int clearance) {
         for (int k = 1; k <= clearance; k++)
-            if (view.solidAt(cx, y + k, cz)) return true;
+            if (probe.solid(cx, y + k, cz)) return true;
         return false;
     }
 
     // A +1 block beside: a solid block at the unit's feet level (terrain raised one step up, or a wall's base).
-    private static boolean raisedBeside(WalkabilityView view, int cx, int cz, int y) {
-        return view.solidAt(cx, y, cz);
+    private static boolean raisedBeside(SolidProbe probe, int cx, int cz, int y) {
+        return probe.solid(cx, y, cz);
     }
 
     // Cost of a single vertical climb step (up or down a wall). Higher than a normal step (1.0) and a step-up

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderConfig.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderConfig.java
@@ -19,6 +19,11 @@ public final class PathfinderConfig {
     // chunks the build queue classifies per server tick and defer the rest; cache hits are free and don't
     // count. Lower = smoother TPS but slower first path, higher = snappier first path but bigger per-tick cost.
     public static final int MAX_CHUNK_BUILDS_PER_TICK = 24;
+    // A block change patches only its (x,z) column (~VERTICAL band cells) instead of evicting the whole 16x16
+    // chunk. Cap how many dirty columns the START-phase drain reclassifies per server tick; the rest stay
+    // stale-but-walkable until a later tick (never removed, so units are never stranded on a transient hole).
+    // ~one chunk's worth of columns, far under the old whole-chunk rebuild cost that this replaces. Tunable.
+    public static final int MAX_COLUMN_RECLASSIFY_PER_TICK = 256;
     // A* searches stay near the surface; only classify a Y band around the path rather than the full
     // world column. SLACK covers the Y+-1 step nodes and goal snapping that reach just outside the band.
     public static final int VERTICAL_RADIUS = 24;

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderConfig.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderConfig.java
@@ -11,6 +11,12 @@ public final class PathfinderConfig {
     // enough to flood the reachable area within MAX_RADIUS so units round obstacles instead of giving up at
     // the near wall. Past ~200k the radius cap, not this, is the limit (raise MAX_RADIUS + MIN_DILATION).
     public static final int MAX_NODES = 250000;
+    // Node budget for a search whose goal cell has NO standable spot nearby (eg. an airborne canopy leaf a
+    // worker can never stand to mine). The goal is unreachable as an exact cell, so a normal search would
+    // flood the full MAX_NODES proving it (~250ms). Cap it low: the worker still best-effort approaches, the
+    // search returns in a few ms, and the gather goal drops the unreachable target. Chaining is also skipped
+    // for this case (see dispatchToPool) since there's nothing to chain toward.
+    public static final int MAX_NODES_UNREACHABLE_GOAL = 8000;
     public static final int MAX_CHAIN_SEGMENTS = 10;
     public static final int MIN_DILATION = 48;
     public static final int QUEUE_BACKPRESSURE_CAP = 500;
@@ -28,6 +34,12 @@ public final class PathfinderConfig {
     // world column. SLACK covers the Y+-1 step nodes and goal snapping that reach just outside the band.
     public static final int VERTICAL_RADIUS = 24;
     public static final int VERTICAL_WINDOW_SLACK = 8;
+
+    // Clearance (unit height in cells) the crowding malus is PRECOMPUTED with, since the cached per-cell crowd[]
+    // is shared by all units. 2 = the common/minimum unit clearance; taller units get a negligibly softer
+    // steering malus, never a correctness change (wideFits/headBlocked stay exact and per-unit). See
+    // WalkabilityGridChunk.crowd and GridNeighbors.crowdingMalus.
+    public static final int MALUS_CLEARANCE = 2;
 
     // The grid's neighbour model only steps +-1 in Y, so it can't express a sheer drop bigger than one block -
     // a unit would stall at the lip of a 2+ block descent (a tall staircase) with no node to advance to, and a

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderWorkerPool.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderWorkerPool.java
@@ -68,13 +68,16 @@ public final class PathfinderWorkerPool {
         }
         RESULTS.clear();
         BUILD_QUEUE.clear();
+        WalkabilityGrid.clearDirty();
         INFLIGHT.set(0);
     }
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent evt) {
-        // START: classify a budget of cold corridor chunks and dispatch any request that's now warm.
+        // START: patch dirty columns from block changes, then classify a budget of cold corridor chunks and
+        // dispatch any request that's now warm. Drain first so paths captured this tick see freshest data.
         if (evt.phase == TickEvent.Phase.START) {
+            WalkabilityGrid.drainDirtyColumns(PathfinderConfig.MAX_COLUMN_RECLASSIFY_PER_TICK);
             processBuildQueue();
             return;
         }

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderWorkerPool.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/PathfinderWorkerPool.java
@@ -1,6 +1,7 @@
 package com.solegendary.reignofnether.unit.pathfinding;
 
 import com.solegendary.reignofnether.ReignOfNether;
+import com.solegendary.reignofnether.resources.ResourceIndex;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.pathfinder.Path;
@@ -69,6 +70,7 @@ public final class PathfinderWorkerPool {
         RESULTS.clear();
         BUILD_QUEUE.clear();
         WalkabilityGrid.clearDirty();
+        ResourceIndex.clearAll();
         INFLIGHT.set(0);
     }
 
@@ -78,6 +80,7 @@ public final class PathfinderWorkerPool {
         // dispatch any request that's now warm. Drain first so paths captured this tick see freshest data.
         if (evt.phase == TickEvent.Phase.START) {
             WalkabilityGrid.drainDirtyColumns(PathfinderConfig.MAX_COLUMN_RECLASSIFY_PER_TICK);
+            ResourceIndex.drainBuildQueue(ResourceIndex.MAX_RESOURCE_CHUNK_SCANS_PER_TICK);
             processBuildQueue();
             return;
         }
@@ -91,7 +94,7 @@ public final class PathfinderWorkerPool {
         }
     }
 
-    public static void submit(Level level, BlockPos start, BlockPos target, int reach, MobilityClass mobility, int clearanceCells, int footprintRadius, float fireCost, boolean canClimb, BooleanSupplier alive, Consumer<Path> onReady) {
+    public static void submit(Level level, BlockPos start, BlockPos target, int reach, MobilityClass mobility, int clearanceCells, int footprintRadius, float fireCost, boolean canClimb, int maxNodes, BooleanSupplier alive, Consumer<Path> onReady) {
         if (POOL == null) {
             onReady.accept(null);
             return;
@@ -103,7 +106,7 @@ public final class PathfinderWorkerPool {
         int dilation = PathfinderConfig.dilationFor(start, target);
         ChunkSnapshot.CaptureRegion region = ChunkSnapshot.regionFor(start, target, dilation);
         BUILD_QUEUE.add(new PendingBuild(level, start, target, reach, mobility, clearanceCells,
-                footprintRadius, fireCost, canClimb, region, alive, onReady));
+                footprintRadius, fireCost, canClimb, maxNodes, region, alive, onReady));
     }
 
     // Classify up to MAX_CHUNK_BUILDS_PER_TICK cold chunks across the parked requests this tick. Cache hits are
@@ -173,6 +176,7 @@ public final class PathfinderWorkerPool {
         final BlockPos start = pb.start;
         final BlockPos target = pb.target;
         final int reach = pb.reach;
+        final int maxNodes = pb.maxNodes;
         final Consumer<Path> onReady = pb.onReady;
         INFLIGHT.incrementAndGet();
         pool.execute(() -> {
@@ -181,12 +185,15 @@ public final class PathfinderWorkerPool {
                 // Chained A*: instead of returning a partial path when goal is outside the
                 // 96-block search radius, run a follow-up search from where the previous one
                 // ended. Up to MAX_CHAIN_SEGMENTS hops. Caps at "actually blocked" after that.
+                // A capped (unreachable-goal) request runs a single best-effort segment - there's
+                // nothing to chain toward, and chaining would multiply its cheap budget.
+                int segLimit = (maxNodes >= PathfinderConfig.MAX_NODES) ? PathfinderConfig.MAX_CHAIN_SEGMENTS : 1;
                 ArrayList<BlockPos> combined = new ArrayList<>();
                 BlockPos cur = start;
                 boolean reached = false;
-                for (int seg = 0; seg < PathfinderConfig.MAX_CHAIN_SEGMENTS; seg++) {
+                for (int seg = 0; seg < segLimit; seg++) {
                     GridAStar.Result r = GridAStar.search(snapshot, cur, target, reach,
-                            PathfinderConfig.MAX_RADIUS, PathfinderConfig.MAX_NODES);
+                            PathfinderConfig.MAX_RADIUS, maxNodes);
                     if (seg == 0) {
                         combined.addAll(r.waypoints);
                     } else {
@@ -222,13 +229,14 @@ public final class PathfinderWorkerPool {
         final int footprintRadius;
         final float fireCost;
         final boolean canClimb;
+        final int maxNodes;
         final ChunkSnapshot.CaptureRegion region;
         final BooleanSupplier alive;
         final Consumer<Path> onReady;
         int cursor = 0;
 
         PendingBuild(Level level, BlockPos start, BlockPos target, int reach, MobilityClass mobility,
-                     int clearanceCells, int footprintRadius, float fireCost, boolean canClimb,
+                     int clearanceCells, int footprintRadius, float fireCost, boolean canClimb, int maxNodes,
                      ChunkSnapshot.CaptureRegion region, BooleanSupplier alive, Consumer<Path> onReady) {
             this.level = level;
             this.start = start;
@@ -239,6 +247,7 @@ public final class PathfinderWorkerPool {
             this.footprintRadius = footprintRadius;
             this.fireCost = fireCost;
             this.canClimb = canClimb;
+            this.maxNodes = maxNodes;
             this.region = region;
             this.alive = alive;
             this.onReady = onReady;

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/RtsPathfinder.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/RtsPathfinder.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.level.pathfinder.Path;
 
+import javax.annotation.Nullable;
 import java.util.function.Consumer;
 
 // Facade: turn a (mob, target) into a vanilla Path delivered to a callback.
@@ -37,14 +38,20 @@ public final class RtsPathfinder {
         // Only spiders with wall-climbing toggled on may scale vertical walls; PoisonSpiderUnit inherits this.
         boolean canClimb = mob instanceof SpiderUnit su && su.isWallClimbing();
         int footprintRadius = footprintRadiusFor(mob);
-        target = snapToWalkable(level, target, mobility, footprintRadius, clearanceCells, fireCost, SNAP_RADIUS);
+        // Snap the goal onto a cell a worker can actually stand in. If none exists nearby (eg. an airborne
+        // canopy leaf), the goal is unreachable as an exact cell: path to it best-effort with a capped node
+        // budget so A* can't flood the full MAX_RADIUS proving the obvious (the 250ms freeze on leaf orders).
+        BlockPos snapped = findStandable(level, target, mobility, footprintRadius, clearanceCells, fireCost, SNAP_RADIUS);
+        boolean reachableGoal = snapped != null;
+        if (reachableGoal) target = snapped;
+        int maxNodes = reachableGoal ? PathfinderConfig.MAX_NODES : PathfinderConfig.MAX_NODES_UNREACHABLE_GOAL;
         if (PathfinderWorkerPool.isInitialised()) {
-            PathfinderWorkerPool.submit(level, start, target, reach, mobility, clearanceCells, footprintRadius, fireCost, canClimb, mob::isAlive, onReady);
+            PathfinderWorkerPool.submit(level, start, target, reach, mobility, clearanceCells, footprintRadius, fireCost, canClimb, maxNodes, mob::isAlive, onReady);
         } else {
             try {
                 int dilation = PathfinderConfig.dilationFor(start, target);
                 ChunkSnapshot snap = ChunkSnapshot.capture(level, start, target, dilation, mobility, clearanceCells, footprintRadius, fireCost, canClimb);
-                GridAStar.Result r = GridAStar.search(snap, start, target, reach, PathfinderConfig.MAX_RADIUS, PathfinderConfig.MAX_NODES);
+                GridAStar.Result r = GridAStar.search(snap, start, target, reach, PathfinderConfig.MAX_RADIUS, maxNodes);
                 onReady.accept(PathConverter.toMcPath(r.waypoints, target, r.reached, snap));
             } catch (Throwable t) {
                 ReignOfNether.LOGGER.error("Sync pathfinder failed", t);
@@ -72,8 +79,12 @@ public final class RtsPathfinder {
         return malus <= 0f ? 1.0f : PathfinderConfig.FIRE_AVOID_COST;
     }
 
-    public static BlockPos snapToWalkable(Level level, BlockPos bp, MobilityClass mobility, int footprintRadius,
-                                          int clearanceCells, float fireCost, int radius) {
+    // Nearest cell a unit can stand in within `radius` of bp (bp itself if already standable), or null if
+    // none exists - meaning the goal is unreachable as an exact cell (eg. an airborne leaf with only air and
+    // leaves around it and no ground within reach). Callers treat null as "approach best-effort, don't flood".
+    @Nullable
+    public static BlockPos findStandable(Level level, BlockPos bp, MobilityClass mobility, int footprintRadius,
+                                         int clearanceCells, float fireCost, int radius) {
         // Snap over a small snapshot so the goal reuses the EXACT walkability + footprint logic A* uses (the
         // snapped goal can never be a cell A* would reject); the +footprintRadius+1 dilation keeps wideFits
         // from reading an uncaptured (BLOCKED) edge cell. canClimb=false: a goal must snap to standable ground,
@@ -82,7 +93,7 @@ public final class RtsPathfinder {
                 mobility, clearanceCells, footprintRadius, fireCost, false);
         if (standable(view, bp.getX(), bp.getY(), bp.getZ())) return bp;
         int bestDistSq = Integer.MAX_VALUE;
-        BlockPos best = bp;
+        BlockPos best = null;
         for (int dz = -radius; dz <= radius; dz++) {
             for (int dx = -radius; dx <= radius; dx++) {
                 for (int dy = -radius; dy <= radius; dy++) {
@@ -96,6 +107,13 @@ public final class RtsPathfinder {
             }
         }
         return best;
+    }
+
+    // Nearest standable cell to bp, or bp itself if none found. Kept for callers that always want a position.
+    public static BlockPos snapToWalkable(Level level, BlockPos bp, MobilityClass mobility, int footprintRadius,
+                                          int clearanceCells, float fireCost, int radius) {
+        BlockPos s = findStandable(level, bp, mobility, footprintRadius, clearanceCells, fireCost, radius);
+        return s != null ? s : bp;
     }
 
     // The unit can stand (and its whole footprint fits) at this cell - the same gate A* applies to a node.

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityBuilder.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityBuilder.java
@@ -54,9 +54,13 @@ public final class WalkabilityBuilder {
                 || floorBs.getBlock() == Blocks.CAMPFIRE
                 || floorBs.getBlock() == Blocks.SOUL_CAMPFIRE) return KIND_FIRE;
 
-        // A fence/wall/closed-gate floor is NOT standable - a unit can't perch on a railing (vanilla agrees),
-        // so don't count it as support; the cell falls through to "no floor" and the unit routes around.
-        if (MiscUtil.isSolidBlocking(level, floor) && !isFenceLike(floorBs)) return KIND_LAND;
+        // A fence/wall/closed-gate floor is NOT standable - a unit can't perch on a railing (vanilla agrees) -
+        // and a LEAF floor must not count either, or units path up onto and over the tree canopy (and goal
+        // snapping lands a worker on top of the very leaf it's told to mine). Don't count these as support; the
+        // cell falls through to "no floor" so the unit routes around, and stands on the real ground below.
+        // BlockTags.LEAVES (allocation-free, covers every tree canopy) instead of BlockUtils.isLeafBlock, whose
+        // List.of fallback would allocate on this per-cell hot path for every ordinary solid floor.
+        if (MiscUtil.isSolidBlocking(level, floor) && !isFenceLike(floorBs) && !floorBs.is(BlockTags.LEAVES)) return KIND_LAND;
         if (floorBs.getFluidState().is(FluidTags.LAVA)) return KIND_LAVA;
         if (!floorBs.getFluidState().isEmpty()) return KIND_WATER;
         return KIND_BLOCKED; // no floor support

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityGrid.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityGrid.java
@@ -1,17 +1,39 @@
 package com.solegendary.reignofnether.unit.pathfinding;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.WeakHashMap;
 
 public final class WalkabilityGrid {
     private static final WeakHashMap<LevelAccessor, WalkabilityGrid> PER_LEVEL = new WeakHashMap<>();
     // Access-ordered (most-recent at head) so we can evict the least-recently-used tail.
     private final Long2ObjectLinkedOpenHashMap<WalkabilityGridChunk> chunks = new Long2ObjectLinkedOpenHashMap<>();
+
+    // Columns awaiting deferred reclassify: chunkKey -> set of packed local columns ((lz<<4)|lx, 0..255).
+    // A block change marks its column dirty instead of evicting the chunk, so reads keep getting the (briefly
+    // stale) cached chunk rather than a BLOCKED hole that would strand units. Drained, budgeted, on the server
+    // tick by drainDirtyColumns. The IntOpenHashSet dedups, so a placement/leaf-decay storm coalesces for free.
+    private final Long2ObjectOpenHashMap<IntOpenHashSet> dirtyColumns = new Long2ObjectOpenHashMap<>();
+
+    // Grids that currently have pending dirty work -> the Level needed to reclassify (the grid is keyed by
+    // LevelAccessor and keeps no back-reference). The Level is held ONLY while work is pending (the entry is
+    // removed when the grid's dirty set empties), so this transient strong ref cannot pin the PER_LEVEL weak
+    // key long-term. Guarded by DIRTY_LOCK.
+    private static final Map<WalkabilityGrid, Level> DIRTY_GRIDS = new IdentityHashMap<>();
+    private static final Object DIRTY_LOCK = new Object();
 
     private WalkabilityGrid() {}
 
@@ -56,18 +78,97 @@ public final class WalkabilityGrid {
         }
     }
 
-    public void invalidateColumn(BlockPos bp) {
-        synchronized (chunks) { chunks.remove(ChunkPos.asLong(bp.getX() >> 4, bp.getZ() >> 4)); }
-    }
-
-    // Invalidate WITHOUT creating a grid for a level that has none yet. Cheap enough to call from the
-    // LevelChunk.setBlockState mixin on every in-game block change (buildings, explosions, commands, player
-    // edits) - and on BOTH sides, so the client-side grid the debug overlay reads stays fresh too.
-    public static void invalidateColumnIfPresent(LevelAccessor level, BlockPos bp) {
+    // Mark the column at bp dirty for deferred reclassify, WITHOUT creating a grid for a level that has none.
+    // Called from the LevelChunk.setBlockState mixin on every in-game block change (mining, building,
+    // explosions, leaf decay, commands). No-op when no grid exists for the level (eg. client side, where the
+    // pathfinder never runs) or the chunk isn't cached. We deliberately do NOT evict: keeping the old chunk
+    // live lets reads return stale-but-walkable data until the deferred drain swaps in the patched chunk,
+    // instead of a removed chunk reading as KIND_BLOCKED and stranding units mid-update.
+    public static void markColumnDirtyIfPresent(Level level, BlockPos bp) {
         if (level == null || bp == null) return;
         WalkabilityGrid grid;
         synchronized (WalkabilityGrid.class) { grid = PER_LEVEL.get(level); }
-        if (grid != null) grid.invalidateColumn(bp);
+        if (grid != null) grid.markColumnDirty(level, bp);
+    }
+
+    private void markColumnDirty(Level level, BlockPos bp) {
+        long key = ChunkPos.asLong(bp.getX() >> 4, bp.getZ() >> 4);
+        WalkabilityGridChunk c;
+        synchronized (chunks) { c = chunks.get(key); }
+        if (c == null) return; // not cached -> nothing to patch; a later getOrBuild reads fresh world state.
+        // A block at world y can only change cells whose feet/head/floor touch it: yIdx y-1, y, y+1. If that
+        // whole [y-1, y+1] span is outside this chunk's band, reclassifying reproduces identical cells - skip.
+        if (bp.getY() + 1 < c.minY() || bp.getY() - 1 >= c.maxY()) return;
+        int packed = ((bp.getZ() & 15) << 4) | (bp.getX() & 15);
+        synchronized (DIRTY_LOCK) {
+            IntOpenHashSet set = dirtyColumns.get(key);
+            if (set == null) { set = new IntOpenHashSet(); dirtyColumns.put(key, set); }
+            set.add(packed);
+            DIRTY_GRIDS.put(this, level);
+        }
+    }
+
+    // Reclassify up to `budget` dirty columns across all levels on the server tick (called from
+    // PathfinderWorkerPool.onServerTick START phase, before processBuildQueue). Copy-on-write: patch a clone
+    // of the live chunk and atomically swap it in, so A* worker threads never see a half-updated chunk and
+    // reads never hit a missing (BLOCKED) chunk. Cheap (~height cells per column) and coalesced.
+    public static void drainDirtyColumns(int budget) {
+        if (budget <= 0) return;
+        List<Map.Entry<WalkabilityGrid, Level>> pending;
+        synchronized (DIRTY_LOCK) {
+            if (DIRTY_GRIDS.isEmpty()) return;
+            // Snapshot into STABLE entries: processDirty removes from DIRTY_GRIDS while we iterate, and an
+            // IdentityHashMap's own Entry views would go stale under that mutation.
+            pending = new ArrayList<>(DIRTY_GRIDS.size());
+            for (Map.Entry<WalkabilityGrid, Level> e : DIRTY_GRIDS.entrySet())
+                pending.add(new AbstractMap.SimpleEntry<>(e.getKey(), e.getValue()));
+        }
+        for (Map.Entry<WalkabilityGrid, Level> e : pending) {
+            if (budget <= 0) break;
+            budget -= e.getKey().processDirty(e.getValue(), budget);
+        }
+    }
+
+    // Drain this grid's dirty columns up to `budget`; returns the number reclassified.
+    private int processDirty(Level level, int budget) {
+        int consumed = 0;
+        while (consumed < budget) {
+            long key;
+            IntArrayList pulled = new IntArrayList();
+            synchronized (DIRTY_LOCK) {
+                if (dirtyColumns.isEmpty()) { DIRTY_GRIDS.remove(this); break; }
+                key = dirtyColumns.keySet().iterator().nextLong();
+                IntOpenHashSet set = dirtyColumns.get(key);
+                IntIterator it = set.iterator();
+                while (it.hasNext() && consumed + pulled.size() < budget) {
+                    pulled.add(it.nextInt());
+                    it.remove();
+                }
+                if (set.isEmpty()) dirtyColumns.remove(key);
+                if (dirtyColumns.isEmpty()) DIRTY_GRIDS.remove(this);
+            }
+            if (pulled.isEmpty()) break;
+            WalkabilityGridChunk original;
+            synchronized (chunks) { original = chunks.get(key); }
+            // null -> chunk was LRU-evicted while dirty; drop the columns, a later getOrBuild rebuilds fresh.
+            if (original != null) {
+                WalkabilityGridChunk replacement = original.reclassifyColumns(
+                        level, new ChunkPos(ChunkPos.getX(key), ChunkPos.getZ(key)), pulled);
+                synchronized (chunks) {
+                    // CAS: only swap if no concurrent getOrBuild replaced it with a fresher/taller chunk in the
+                    // meantime (that rebuild already read at-least-as-new world state, so drop our patch). Plain
+                    // put, not putAndMoveToFirst, so a passive recompute doesn't perturb LRU order.
+                    if (chunks.get(key) == original) chunks.put(key, replacement);
+                }
+            }
+            consumed += pulled.size();
+        }
+        return consumed;
+    }
+
+    // Drop all pending dirty work (server stop), so the static DIRTY_GRIDS can't pin Levels across a restart.
+    public static void clearDirty() {
+        synchronized (DIRTY_LOCK) { DIRTY_GRIDS.clear(); }
     }
 
     // Snapshot of the currently-built (cached) chunk keys, for the debug overlay.

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityGridChunk.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityGridChunk.java
@@ -2,6 +2,8 @@ package com.solegendary.reignofnether.unit.pathfinding;
 
 import com.solegendary.reignofnether.resources.BlockUtils;
 import com.solegendary.reignofnether.util.MiscUtil;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -45,28 +47,63 @@ public final class WalkabilityGridChunk {
                 int wz = baseZ + dz;
                 for (int y = minY; y < maxY; y++) {
                     int i = idx(dx, y - minY, dz);
-                    cellKind[i] = WalkabilityBuilder.classify(level, wx, y, wz);
-                    // Leaves report non-solid but have full collision, so count them as body-blocking here
-                    // (classify still treats them as no floor support, so units don't walk on them). Fences,
-                    // walls and closed fence gates are 1.5-tall barriers too - count them as body-blocking so
-                    // they register as walls for the crowding malus and block footprints, like solid blocks.
-                    mp.set(wx, y, wz);
-                    BlockState bs = level.getBlockState(mp);
-                    boolean cellSolid = MiscUtil.isSolidBlocking(level, mp) || BlockUtils.isLeafBlock(bs)
-                            || WalkabilityBuilder.isFenceLike(bs);
-                    // A fence/wall directly BELOW is 1.5 tall and reaches up into this cell. Mark this cell solid
-                    // too so wallBeside (which probes ABOVE the feet, skipping the feet cell as a climbable step)
-                    // actually detects a ground-level fence/wall as a wall - otherwise a 1-tall fence sitting at a
-                    // neighbour's feet is invisible to the crowding malus.
-                    if (!cellSolid) {
-                        mpBelow.set(wx, y - 1, wz);
-                        if (WalkabilityBuilder.isFenceLike(level.getBlockState(mpBelow))) cellSolid = true;
-                    }
-                    solid[i] = cellSolid ? (byte) 1 : 0;
+                    classifyCell(level, wx, y, wz, cellKind, solid, i, mp, mpBelow);
                 }
             }
         }
         return new WalkabilityGridChunk(minY, height, cellKind, solid);
+    }
+
+    // Re-derive ONE local column (packed (lz<<4)|lx) into clones of this chunk's arrays, returning a NEW
+    // immutable chunk - never mutating the receiver. Worker-pool threads holding the old chunk through a
+    // captured snapshot keep reading consistent (if briefly stale) data; the swap into the cache is atomic
+    // (see WalkabilityGrid.drainDirtyColumns). Same minY/height as the original, so covers() and every
+    // snapshot's band assumption stay valid. ~height cell classifications per column vs SIZE*SIZE for build().
+    public WalkabilityGridChunk reclassifyColumns(Level level, ChunkPos cp, IntCollection localColumns) {
+        byte[] newKind = cellKind.clone();
+        byte[] newSolid = solid.clone();
+        int baseX = cp.getMinBlockX();
+        int baseZ = cp.getMinBlockZ();
+        int maxY = minY + height;
+        BlockPos.MutableBlockPos mp = new BlockPos.MutableBlockPos();
+        BlockPos.MutableBlockPos mpBelow = new BlockPos.MutableBlockPos();
+        IntIterator it = localColumns.iterator();
+        while (it.hasNext()) {
+            int packed = it.nextInt();
+            int lx = packed & 15;
+            int lz = (packed >> 4) & 15;
+            int wx = baseX + lx;
+            int wz = baseZ + lz;
+            for (int y = minY; y < maxY; y++) {
+                int i = idx(lx, y - minY, lz);
+                classifyCell(level, wx, y, wz, newKind, newSolid, i, mp, mpBelow);
+            }
+        }
+        return new WalkabilityGridChunk(minY, height, newKind, newSolid);
+    }
+
+    // Classify one cell (x,y,z) into cellKind[i]/solid[i]. The single definition of how a cell becomes
+    // walkable + body-blocking, shared by build() and reclassifyColumns() so the two can never drift.
+    private static void classifyCell(Level level, int wx, int y, int wz, byte[] cellKind, byte[] solid, int i,
+                                     BlockPos.MutableBlockPos mp, BlockPos.MutableBlockPos mpBelow) {
+        cellKind[i] = WalkabilityBuilder.classify(level, wx, y, wz);
+        // Leaves report non-solid but have full collision, so count them as body-blocking here
+        // (classify still treats them as no floor support, so units don't walk on them). Fences,
+        // walls and closed fence gates are 1.5-tall barriers too - count them as body-blocking so
+        // they register as walls for the crowding malus and block footprints, like solid blocks.
+        mp.set(wx, y, wz);
+        BlockState bs = level.getBlockState(mp);
+        boolean cellSolid = MiscUtil.isSolidBlocking(level, mp) || BlockUtils.isLeafBlock(bs)
+                || WalkabilityBuilder.isFenceLike(bs);
+        // A fence/wall directly BELOW is 1.5 tall and reaches up into this cell. Mark this cell solid
+        // too so wallBeside (which probes ABOVE the feet, skipping the feet cell as a climbable step)
+        // actually detects a ground-level fence/wall as a wall - otherwise a 1-tall fence sitting at a
+        // neighbour's feet is invisible to the crowding malus.
+        if (!cellSolid) {
+            mpBelow.set(wx, y - 1, wz);
+            if (WalkabilityBuilder.isFenceLike(level.getBlockState(mpBelow))) cellSolid = true;
+        }
+        solid[i] = cellSolid ? (byte) 1 : 0;
     }
 
     private static int idx(int localX, int yIdx, int localZ) {

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityGridChunk.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityGridChunk.java
@@ -4,6 +4,7 @@ import com.solegendary.reignofnether.resources.BlockUtils;
 import com.solegendary.reignofnether.util.MiscUtil;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -16,16 +17,26 @@ import net.minecraft.world.level.block.state.BlockState;
 public final class WalkabilityGridChunk {
     public static final int SIZE = 16;
 
+    // Crowding malus is quantised to a byte: stored = round(malus * CROWD_SCALE), read = byte / CROWD_SCALE.
+    // Malus range is 0..3.0, so *16 (step 0.0625, max 48) fits comfortably in an unsigned byte.
+    private static final int CROWD_SCALE = 16;
+
     private final int minY;
     private final int height;
     private final byte[] cellKind;
     private final byte[] solid; // 1 if the block in this cell is solid-blocking (blocks a unit's head/body)
+    // Precomputed GridNeighbors.crowdingMalus per cell (quantised). Baked here once instead of rescanned for
+    // every neighbour of every A* node - the malus is a pure function of solid[] + a fixed clearance, so it
+    // belongs in the cache next to cellKind/solid. Computed from the LOCAL solid[] only (out-of-chunk = open),
+    // a small seam approximation that's fine for a soft steering term and keeps build/reclassify pure array work.
+    private final byte[] crowd;
 
-    private WalkabilityGridChunk(int minY, int height, byte[] cellKind, byte[] solid) {
+    private WalkabilityGridChunk(int minY, int height, byte[] cellKind, byte[] solid, byte[] crowd) {
         this.minY = minY;
         this.height = height;
         this.cellKind = cellKind;
         this.solid = solid;
+        this.crowd = crowd;
     }
 
     public static WalkabilityGridChunk build(Level level, ChunkPos cp, int windowMinY, int windowMaxY) {
@@ -37,6 +48,7 @@ public final class WalkabilityGridChunk {
         int height = maxY - minY;
         byte[] cellKind = new byte[SIZE * SIZE * height];
         byte[] solid = new byte[SIZE * SIZE * height];
+        byte[] crowd = new byte[SIZE * SIZE * height];
         BlockPos.MutableBlockPos mp = new BlockPos.MutableBlockPos();
         BlockPos.MutableBlockPos mpBelow = new BlockPos.MutableBlockPos();
         int baseX = cp.getMinBlockX();
@@ -51,7 +63,12 @@ public final class WalkabilityGridChunk {
                 }
             }
         }
-        return new WalkabilityGridChunk(minY, height, cellKind, solid);
+        // Second pass: crowd[] reads neighbouring solid[] cells, so it needs the whole chunk's solid[] filled.
+        GridNeighbors.SolidProbe probe = solidProbe(solid, minY, height, baseX, baseZ);
+        for (int lz = 0; lz < SIZE; lz++)
+            for (int lx = 0; lx < SIZE; lx++)
+                computeCrowdColumn(probe, crowd, minY, height, baseX, baseZ, lx, lz);
+        return new WalkabilityGridChunk(minY, height, cellKind, solid, crowd);
     }
 
     // Re-derive ONE local column (packed (lz<<4)|lx) into clones of this chunk's arrays, returning a NEW
@@ -62,6 +79,7 @@ public final class WalkabilityGridChunk {
     public WalkabilityGridChunk reclassifyColumns(Level level, ChunkPos cp, IntCollection localColumns) {
         byte[] newKind = cellKind.clone();
         byte[] newSolid = solid.clone();
+        byte[] newCrowd = crowd.clone();
         int baseX = cp.getMinBlockX();
         int baseZ = cp.getMinBlockZ();
         int maxY = minY + height;
@@ -79,7 +97,27 @@ public final class WalkabilityGridChunk {
                 classifyCell(level, wx, y, wz, newKind, newSolid, i, mp, mpBelow);
             }
         }
-        return new WalkabilityGridChunk(minY, height, newKind, newSolid);
+        // A changed column shifts the crowd malus of every cell within 2 of it (crowdingMalus reads a 5x5
+        // neighbourhood), so recompute crowd over the dirty columns DILATED by 2, off the patched solid[].
+        IntOpenHashSet dilated = new IntOpenHashSet();
+        IntIterator dit = localColumns.iterator();
+        while (dit.hasNext()) {
+            int packed = dit.nextInt();
+            int clx = packed & 15, clz = (packed >> 4) & 15;
+            for (int ddz = -2; ddz <= 2; ddz++)
+                for (int ddx = -2; ddx <= 2; ddx++) {
+                    int nlx = clx + ddx, nlz = clz + ddz;
+                    if (nlx < 0 || nlx >= SIZE || nlz < 0 || nlz >= SIZE) continue;
+                    dilated.add((nlz << 4) | nlx);
+                }
+        }
+        GridNeighbors.SolidProbe probe = solidProbe(newSolid, minY, height, baseX, baseZ);
+        IntIterator cit = dilated.iterator();
+        while (cit.hasNext()) {
+            int p = cit.nextInt();
+            computeCrowdColumn(probe, newCrowd, minY, height, baseX, baseZ, p & 15, (p >> 4) & 15);
+        }
+        return new WalkabilityGridChunk(minY, height, newKind, newSolid, newCrowd);
     }
 
     // Classify one cell (x,y,z) into cellKind[i]/solid[i]. The single definition of how a cell becomes
@@ -110,6 +148,27 @@ public final class WalkabilityGridChunk {
         return (yIdx * SIZE + localZ) * SIZE + localX;
     }
 
+    // A solid-probe over one chunk's local solid[]: world (sx,sy,sz) outside this chunk's columns or band reads
+    // as open (false). The seam approximation that lets crowd[] be precomputed without cross-chunk reads.
+    private static GridNeighbors.SolidProbe solidProbe(byte[] solid, int minY, int height, int baseX, int baseZ) {
+        return (sx, sy, sz) -> {
+            int lx = sx - baseX, lz = sz - baseZ, yIdx = sy - minY;
+            if (lx < 0 || lx >= SIZE || lz < 0 || lz >= SIZE || yIdx < 0 || yIdx >= height) return false;
+            return solid[idx(lx, yIdx, lz)] != 0;
+        };
+    }
+
+    // Fill crowd[] for one local column across the whole band, from the shared GridNeighbors.crowdingMalus math
+    // (fixed MALUS_CLEARANCE, since one cached value serves all units), quantised to a byte.
+    private static void computeCrowdColumn(GridNeighbors.SolidProbe probe, byte[] crowd, int minY, int height,
+                                           int baseX, int baseZ, int lx, int lz) {
+        int wx = baseX + lx, wz = baseZ + lz;
+        for (int yIdx = 0; yIdx < height; yIdx++) {
+            float malus = GridNeighbors.crowdingMalus(probe, PathfinderConfig.MALUS_CLEARANCE, wx, minY + yIdx, wz);
+            crowd[idx(lx, yIdx, lz)] = (byte) Math.min(255, Math.round(malus * CROWD_SCALE));
+        }
+    }
+
     public byte kindAt(int wx, int y, int wz) {
         int yIdx = y - minY;
         if (yIdx < 0 || yIdx >= height) return WalkabilityBuilder.KIND_BLOCKED;
@@ -121,6 +180,13 @@ public final class WalkabilityGridChunk {
         int yIdx = y - minY;
         if (yIdx < 0 || yIdx >= height) return false;
         return solid[idx(wx & 15, yIdx, wz & 15)] != 0;
+    }
+
+    // Precomputed crowding malus for this cell (dequantised). Out-of-band reads as 0 (open, no steering cost).
+    public float crowdAt(int wx, int y, int wz) {
+        int yIdx = y - minY;
+        if (yIdx < 0 || yIdx >= height) return 0f;
+        return (crowd[idx(wx & 15, yIdx, wz & 15)] & 0xFF) / (float) CROWD_SCALE;
     }
 
     public int minY() { return minY; }

--- a/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityView.java
+++ b/src/main/java/com/solegendary/reignofnether/unit/pathfinding/WalkabilityView.java
@@ -18,6 +18,11 @@ public interface WalkabilityView {
     // True if the block in this cell is solid-blocking. Used to require headroom before a unit steps up a ledge.
     boolean solidAt(int wx, int y, int wz);
 
+    // Precomputed crowding malus for this cell (the steering cost that keeps units off walls/edges/corners),
+    // baked into the chunk at build time instead of rescanned per A* node. 0 for open cells / outside the view.
+    // See GridNeighbors.crowdingMalus and WalkabilityGridChunk.crowdAt.
+    float crowdAt(int wx, int y, int wz);
+
     // True if this unit may use vertical climb moves (cling to a climbable wall, no floor needed). False for
     // non-climbers, so they path exactly as before. Only spiders with wall-climbing toggled on set this.
     boolean canClimb();


### PR DESCRIPTION
Fixed the worker/pathfinding lag, it was 4 things stacking:

1. Workers re-pathing every second : backoff keyed off canReach(), but a worker heading to a mineable block always reports "can't reach" (you stand next to it, not in it), so arrived workers froze and retried. Now it's based on actual forward progress.
2. Inefficient resource scanning : replaced per-worker block scans with one shared cached resource map every worker reads from.
3. Pathing to invalid blocks (leaves) : unreachable targets flooded the full search budget (~250ms) then retried. Now they fail fast on a tiny capped budget. Also leaves were walkable floor (units climbed the canopy) fixed.
4. A* itself too slow : the wall-avoidance steering cost was recomputed per cell, per unit, per search on the pathfinding thread (~95% of A*'s time), even though it only depends on terrain. Now it's computed once when the navmesh chunk is cached and shared by all units.

Overall I improved RTS pathfinding speed by ~10×. Tested with 200 workers mining on a server : held 66 TPS.